### PR TITLE
SEO/AdSense: index privacy+terms, add canonical + meta

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -2,8 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="robots" content="noindex, follow">
-  <title>Privacy Policy — strongpasswordgenerator.dev</title>
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://strongpasswordgenerator.dev/privacy.html" />
+  <meta name="description" content="Privacy policy for strongpasswordgenerator.dev: our password tools run locally in your browser and we do not collect or store generated passwords." />
+  <meta property="og:url" content="https://strongpasswordgenerator.dev/privacy.html" />
+  <meta property="og:title" content="Privacy Policy — strongpasswordgenerator.dev" />
+  <meta property="og:description" content="Our password tools run locally in your browser. We do not collect or store generated passwords." />
+  <meta name="twitter:card" content="summary" />
+<title>Privacy Policy — strongpasswordgenerator.dev</title>
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>

--- a/terms.html
+++ b/terms.html
@@ -2,8 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="robots" content="noindex, follow">
-  <title>Terms of Service — strongpasswordgenerator.dev</title>
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://strongpasswordgenerator.dev/terms.html" />
+  <meta name="description" content="Terms of service for strongpasswordgenerator.dev. Use at your own risk. Password generation occurs locally in your browser." />
+  <meta property="og:url" content="https://strongpasswordgenerator.dev/terms.html" />
+  <meta property="og:title" content="Terms of Service — strongpasswordgenerator.dev" />
+  <meta property="og:description" content="Password generation occurs locally in your browser. Please review terms of service." />
+  <meta name="twitter:card" content="summary" />
+<title>Terms of Service — strongpasswordgenerator.dev</title>
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>


### PR DESCRIPTION
This PR improves AdSense/SEO hygiene for policy pages:\n\n- Remove noindex from privacy/terms (set robots: index,follow)\n- Add canonical URLs, meta descriptions, and basic OG/Twitter metadata\n\nRationale: policy pages are trust signals; making them indexable + well-formed can help review + overall site quality.\n\nNo functional JS changes.