### PR TITLE
fix: contact form mailto fallback

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -35,14 +35,7 @@
 </header>
 
 <main class="info-section">
-  <form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field" style="display:grid;gap:12px;max-width:640px;">
-    <input type="hidden" name="form-name" value="contact">
-    <p hidden><label>Don’t fill this out: <input name="bot-field"></label></p>
-    <label><span>Name</span><input name="name" required style="width:100%;padding:10px;border:1px solid #e1e8ed;border-radius:6px;"></label>
-    <label><span>Email</span><input name="email" type="email" required style="width:100%;padding:10px;border:1px solid #e1e8ed;border-radius:6px;"></label>
-    <label><span>Message</span><textarea name="message" rows="6" required style="width:100%;padding:10px;border:1px solid #e1e8ed;border-radius:6px;"></textarea></label>
-    <button class="btn btn-primary" type="submit">Send</button>
-  </form>
+  <p style="color:#6b7280;font-size:14px;">Use the form below. If it fails, it will fall back to opening your email app.</p>
 
   <form id="contactForm" method="post" action="/api/contact" style="margin-top:16px;display:grid;gap:10px;max-width:520px;">
     <label>
@@ -51,7 +44,7 @@
     </label>
     <label>
       <div style="font-weight:600;margin-bottom:4px;">Email</div>
-      <input name="email" type="email" autocomplete="email" style="width:100%;padding:10px;border:1px solid #e5e7eb;border-radius:10px;" />
+      <input name="email" type="email" required autocomplete="email" style="width:100%;padding:10px;border:1px solid #e5e7eb;border-radius:10px;" />
     </label>
     <label>
       <div style="font-weight:600;margin-bottom:4px;">Message</div>
@@ -68,21 +61,35 @@
 </div>
 
 <script>
-const f=document.getElementById('contactForm');
-if(f){
-  f.addEventListener('submit', async (e)=>{
+const f = document.getElementById('contactForm');
+function mailtoFallback(fd){
+  const name = (fd.get('name')||'').toString();
+  const email = (fd.get('email')||'').toString();
+  const message = (fd.get('message')||'').toString();
+  const subject = encodeURIComponent('Contact form submission');
+  const body = encodeURIComponent(`Name: ${name}
+Email: ${email}
+
+${message}`);
+  window.location.href = `mailto:contact@strongpasswordgenerator.dev?subject=${subject}&body=${body}`;
+}
+if (f) {
+  f.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const status=document.getElementById('contactStatus');
-    status.textContent='Sending…';
-    const fd=new FormData(f);
-    const r=await fetch('/api/contact', {method:'POST', body: fd});
-    const j=await r.json().catch(()=>({ok:false,error:'bad_json'}));
-    if(r.ok && j.ok){
-      status.textContent='Sent. If you don't hear back, email contact@strongpasswordgenerator.dev';
-      f.reset();
-    } else {
-      status.textContent='Failed to send. Please email contact@strongpasswordgenerator.dev';
-    }
+    const status = document.getElementById('contactStatus');
+    status.textContent = 'Sending…';
+    const fd = new FormData(f);
+    try {
+      const r = await fetch('/api/contact', { method: 'POST', body: fd });
+      const j = await r.json().catch(() => ({ ok: false }));
+      if (r.ok && j.ok) {
+        status.textContent = 'Sent. If you do not hear back, email contact@strongpasswordgenerator.dev';
+        f.reset();
+        return;
+      }
+    } catch (_) {}
+    status.textContent = 'Could not submit here — opening your email app instead.';
+    mailtoFallback(fd);
   });
 }
 </script>


### PR DESCRIPTION
Makes contact form degrade gracefully while Cloudflare Pages Functions are being configured.\n\n- Removes duplicate Netlify form block\n- Adds name + requires email\n- If POST /api/contact fails, opens a mailto: draft with the message\n\nSafe to merge.