### PR TITLE
Add password manager affiliate links

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -19,6 +19,11 @@ interface PostMeta {
   slug: string;
 }
 
+const bitwardenRecommendedSlugs = new Set([
+  'bitwarden-setup-guide',
+  'lastpass-alternatives',
+]);
+
 export async function generateStaticParams() {
   const index: PostMeta[] = postsIndex;
   return index.map((post) => ({ slug: post.slug }));
@@ -82,6 +87,21 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           <p className="text-slate-500 text-base leading-relaxed mb-6 border-l-4 border-indigo-200 pl-4 italic">
             {post.excerpt}
           </p>
+
+          {bitwardenRecommendedSlugs.has(post.slug) && (
+            <blockquote className="bg-indigo-50 border-l-4 border-indigo-300 rounded-r-xl p-4 my-6 text-sm text-indigo-900">
+              <strong>Recommended:</strong> We use and recommend{' '}
+              <a
+                href="https://bitwarden.com/?utm_source=strongpasswordgenerator"
+                target="_blank"
+                rel="noopener noreferrer sponsored"
+                className="font-semibold underline hover:text-indigo-700"
+              >
+                Bitwarden
+              </a>{' '}
+              — free, open-source, and trusted by millions.
+            </blockquote>
+          )}
 
           <div
             className="prose prose-slate max-w-none"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,7 @@ const CHAR_SETS = {
 };
 
 const tips = [
-  { title: "Use a Password Manager", text: "Don't memorize passwords - use a password manager like Bitwarden or 1Password to generate and store unique passwords for every site." },
+  { title: "Use a Password Manager", text: "Don't memorize passwords - use a password manager like Bitwarden or NordPass to generate and store unique passwords for every site." },
   { title: "Enable 2FA Wherever Possible", text: "Two-factor authentication adds an extra layer of security. Use an authenticator app instead of SMS when available." },
   { title: "Never Reuse Passwords", text: "If one site gets breached, all your accounts are vulnerable. Use unique passwords for every account." },
   { title: "Longer is Stronger", text: "A 20-character password with only lowercase letters is often stronger than an 8-character one with special characters." },
@@ -295,7 +295,18 @@ export default function Home() {
             {tips.map((tip, i) => (
               <div key={i} className="bg-slate-50 p-4 rounded-lg">
                 <h3 className="font-semibold text-indigo-600 mb-2">💡 {tip.title}</h3>
-                <p className="text-sm text-slate-500">{tip.text}</p>
+                <p className="text-sm text-slate-500">
+                  {tip.text}
+                  {tip.title === "Use a Password Manager" && (
+                    <>
+                      {' '}
+                      Learn more about our{' '}
+                      <Link href="/recommended-tools" className="text-indigo-600 underline hover:text-indigo-800">
+                        recommended password managers →
+                      </Link>
+                    </>
+                  )}
+                </p>
               </div>
             ))}
           </div>

--- a/src/app/recommended-tools/page.tsx
+++ b/src/app/recommended-tools/page.tsx
@@ -13,7 +13,7 @@ const tools = [
         name: 'NordPass',
         tagline: 'Zero-knowledge password manager with a generous free tier',
         description: 'NordPass uses XChaCha20 encryption and a zero-knowledge architecture — even NordPass cannot see your passwords. It includes a built-in data breach scanner, password health report, and secure sharing. The free tier supports unlimited passwords.',
-        url: 'https://www.kqzyfj.com/click-101754888-17262576',
+        url: 'https://nordpass.com/special/strongpasswordgenerator/',
         badge: 'Best Free Option',
         badgeColor: '#10b981',
         sponsored: true,
@@ -23,10 +23,10 @@ const tools = [
         name: 'Bitwarden',
         tagline: 'The open-source password manager trusted by millions',
         description: 'Bitwarden is the leading open-source password manager — fully audited, end-to-end encrypted, and free for individuals. Self-host if you want full control, or use their cloud. Bitwarden supports TOTP, passkeys, and secure sharing, and the free tier has no practical limits.',
-        url: 'https://bitwarden.com',
+        url: 'https://bitwarden.com/?utm_source=strongpasswordgenerator',
         badge: 'Open Source',
         badgeColor: '#175DDC',
-        sponsored: false,
+        sponsored: true,
         features: ['End-to-end encrypted vault', 'Fully open-source & audited', 'Free tier with unlimited passwords', 'TOTP authenticator built-in', 'Self-hosting option available'],
       },
       {
@@ -150,7 +150,7 @@ export default function RecommendedToolsPage() {
                     </ul>
                     <a
                       href={tool.url}
-                      rel={tool.sponsored ? 'noopener sponsored' : 'noopener'}
+                      rel={tool.sponsored ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
                       target="_blank"
                       className="inline-block bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-semibold px-5 py-2.5 rounded-xl text-sm hover:opacity-90 transition"
                     >


### PR DESCRIPTION
Closes #16

## What changed
Updated the recommended tools page to use the requested Bitwarden and NordPass affiliate URLs with sponsored link attributes. Added an internal link from the homepage password manager tip to the recommended tools page. Added a Bitwarden recommendation callout near the top of the two most relevant password-manager blog posts.

## Files changed
- `src/app/recommended-tools/page.tsx` — updated Bitwarden/NordPass URLs and sponsored rel attributes
- `src/app/page.tsx` — linked the password manager tip to `/recommended-tools`
- `src/app/blog/[slug]/page.tsx` — shows the Bitwarden callout on relevant password-manager posts

## Verification
- [ ] CI passes (lint + build + scope)
- [x] `npm run lint` passed locally
- [x] `npx next build --webpack` passed locally
- [ ] `npm run build` attempted locally; Turbopack failed in the Codex sandbox with a process/port binding error, so CI is the source of truth for the normal build command