### PR TITLE
Fix canonical metadata in root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,14 @@
 import type { Metadata } from "next";
 import "./globals.css";
+
 export const metadata: Metadata = {
+  metadataBase: new URL("https://strongpasswordgenerator.dev"),
   title: "Strong Password Generator | Free Security Suite",
   description: "Free password generator with advanced security analysis. Generate cryptographically secure passwords, check strength, estimate crack time, and monitor password health.",
   keywords: "password generator, password strength, security checker, password health, cryptographically secure, password entropy, crack time calculator",
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
     title: "Strong Password Generator | Free Security Suite",
     description: "Generate cryptographically secure passwords, with advanced security analysis.",
@@ -26,7 +31,6 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <link rel="canonical" href="https://strongpasswordgenerator.dev/" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
 
         <script


### PR DESCRIPTION
Closes #34

## Summary
- add `metadataBase` to the root metadata so canonical URLs resolve from the production domain
- add homepage `alternates.canonical` metadata in `src/app/layout.tsx`
- remove the old hand-authored canonical `<link>` to avoid duplicate canonical tags in the rendered head
- leave `src/app/blog/[slug]/page.tsx` unchanged because it already includes `alternates.canonical` per slug

## Verification
- Not run locally in this environment; relying on GitHub CI for `npm run build`

Issue body snapshot at claim: `ac4030f279246b88`