### PR TITLE
agios infra: fix router workflow node cache order

### DIFF
--- a/.github/workflows/agios-builder-router.yml
+++ b/.github/workflows/agios-builder-router.yml
@@ -32,18 +32,18 @@ jobs:
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Node.js (for build verification)
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: npm
-          cache-dependency-path: package-lock.json
-
       - name: Checkout target repo
         uses: actions/checkout@v4
         with:
           path: target
           fetch-depth: 0
+
+      - name: Set up Node.js (for build verification)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: target/package-lock.json
 
       - name: Checkout AGIOS control repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes the SPG AGIOS canary failure from issue #42 / run `28000405941`.

The workflow configured `actions/setup-node` with `cache-dependency-path: package-lock.json` before checking out the repository, so setup-node failed with:

`Some specified paths were not resolved, unable to cache dependencies.`

This PR:
- checks out the target repo before setup-node
- points setup-node cache at `target/package-lock.json`

## Risk

Low. This only changes the AGIOS caller workflow and does not touch app runtime code, AdSense files, sitemap files, or content.