### PR TITLE
feat: add password checker section

### DIFF
--- a/src/app/components/PasswordChecker.tsx
+++ b/src/app/components/PasswordChecker.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+function calculateEntropy(pwd: string): number {
+  let charsetSize = 0;
+  if (/[a-z]/.test(pwd)) charsetSize += 26;
+  if (/[A-Z]/.test(pwd)) charsetSize += 26;
+  if (/[0-9]/.test(pwd)) charsetSize += 10;
+  if (/[^a-zA-Z0-9]/.test(pwd)) charsetSize += 32;
+  if (charsetSize === 0) return 0;
+  return pwd.length * Math.log2(charsetSize);
+}
+
+function estimateCrackTime(entropy: number): string {
+  const guessesPerSecond = 1e10;
+  const combinations = Math.pow(2, entropy);
+  const seconds = combinations / guessesPerSecond / 2;
+
+  if (seconds < 1) return 'Instantly';
+  if (seconds < 60) return `${Math.round(seconds)} seconds`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)} minutes`;
+  if (seconds < 86400) return `${Math.round(seconds / 3600)} hours`;
+  if (seconds < 31536000) return `${Math.round(seconds / 86400)} days`;
+  if (seconds < 31536000 * 1000) return `${Math.round(seconds / 31536000)} years`;
+  if (seconds < 31536000 * 1e6) return `${Math.round(seconds / 31536000 / 1000)} thousand years`;
+  if (seconds < 31536000 * 1e9) return `${Math.round(seconds / 31536000 / 1e6)} million years`;
+  if (seconds < 31536000 * 1e12) return `${Math.round(seconds / 31536000 / 1e9)} billion years`;
+  return 'Centuries+';
+}
+
+function calculateStrength(pwd: string): { score: number; label: string } {
+  const entropy = calculateEntropy(pwd);
+
+  if (pwd.length === 0) return { score: 0, label: '' };
+  if (entropy < 28) return { score: 1, label: 'Very Weak' };
+  if (entropy < 36) return { score: 2, label: 'Weak' };
+  if (entropy < 60) return { score: 3, label: 'Fair' };
+  if (entropy < 80) return { score: 4, label: 'Strong' };
+  return { score: 5, label: 'Very Strong' };
+}
+
+export default function PasswordChecker() {
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [strengthScore, setStrengthScore] = useState(0);
+  const [strengthLabel, setStrengthLabel] = useState('');
+  const [crackTime, setCrackTime] = useState('');
+  const [entropy, setEntropy] = useState(0);
+
+  const getStrengthColor = useCallback(() => {
+    const colors = ['#ff6b6b', '#ff6b6b', '#feca57', '#feca57', '#26de81', '#26de81'];
+    return colors[strengthScore] || '#8899a6';
+  }, [strengthScore]);
+
+  const updatePassword = (nextPassword: string) => {
+    const nextEntropy = calculateEntropy(nextPassword);
+    const nextStrength = calculateStrength(nextPassword);
+
+    setPassword(nextPassword);
+    setEntropy(nextEntropy);
+    setStrengthScore(nextStrength.score);
+    setStrengthLabel(nextStrength.label);
+    setCrackTime(estimateCrackTime(nextEntropy));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label htmlFor="password-checker-input" className="block text-sm font-medium text-slate-500 mb-2">
+          Password to check
+        </label>
+        <div className="relative">
+          <input
+            id="password-checker-input"
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => updatePassword(e.target.value)}
+            aria-label="Enter password to check"
+            className="w-full bg-slate-50 border border-slate-200 rounded-lg px-4 py-3 pr-12 font-mono text-indigo-600"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword((current) => !current)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            className="absolute inset-y-0 right-0 flex w-12 items-center justify-center text-lg text-slate-500 hover:text-indigo-600"
+          >
+            {showPassword ? '🙈' : '👁'}
+          </button>
+        </div>
+        <p className="mt-2 text-xs italic text-slate-400">
+          Your password is never sent anywhere — all analysis happens locally in your browser.
+        </p>
+      </div>
+
+      {password.length > 0 && (
+        <div aria-live="polite" className="space-y-3 rounded-xl border border-slate-100 bg-slate-50 p-4">
+          <div className="flex justify-between text-sm">
+            <span className="text-slate-500">Strength:</span>
+            <span style={{ color: getStrengthColor() }}>{strengthLabel}</span>
+          </div>
+          <div className="h-2 bg-slate-50 rounded-full overflow-hidden">
+            <div
+              className="h-full transition-all duration-300"
+              style={{ width: `${(strengthScore / 5) * 100}%`, backgroundColor: getStrengthColor() }}
+            />
+          </div>
+          <div className="grid gap-2 text-sm text-slate-500 sm:grid-cols-2">
+            <div>
+              Entropy: <span className="text-slate-700">{Math.round(entropy)} bits</span>
+            </div>
+            <div>
+              Estimated crack time: <span className="text-slate-700">{crackTime}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import PassphraseGenerator from './components/PassphraseGenerator';
+import PasswordChecker from './components/PasswordChecker';
 import AffiliateCTA from './components/AffiliateCTA';
 
 import Link from 'next/link';
@@ -345,6 +346,11 @@ export default function Home() {
           <PassphraseGenerator />
         </div>
 
+        <div className="bg-white rounded-3xl shadow-xl shadow-slate-200/50 p-6 border border-slate-100">
+          <h2 className="text-lg font-semibold mb-2">🔍 Check Your Password</h2>
+          <p className="text-sm text-slate-500 mb-4">Already have a password? See how strong it really is.</p>
+          <PasswordChecker />
+        </div>
 
         {/* Newsletter */}
         <div className="bg-gradient-to-r from-indigo-50 to-blue-50 rounded-3xl border border-indigo-100 p-8 text-center">


### PR DESCRIPTION
## Summary
- Add a self-contained client-side PasswordChecker component for checking existing passwords locally.
- Insert the new Check Your Password card between Passphrase Generator and Newsletter on the homepage.

## Verification
- npm run build && npm run lint
- Issue body snapshot at claim: 60aaa81b16568b99

Closes #42