### PR TITLE
seo: add social metadata to static pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,8 +1,21 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'About | Strong Password Generator',
   description: 'Learn about StrongPasswordGenerator.dev — a free tool to generate cryptographically secure passwords and learn password security best practices.',
+  openGraph: {
+    type: 'website',
+    url: 'https://strongpasswordgenerator.dev/about',
+    siteName: 'Strong Password Generator',
+    title: 'About | Strong Password Generator',
+    description: 'Learn about StrongPasswordGenerator.dev — a free tool to generate cryptographically secure passwords and learn password security best practices.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About | Strong Password Generator',
+    description: 'Learn about StrongPasswordGenerator.dev — a free tool to generate cryptographically secure passwords and learn password security best practices.',
+  },
 };
 
 export default function AboutPage() {

--- a/src/app/recommended-tools/page.tsx
+++ b/src/app/recommended-tools/page.tsx
@@ -1,8 +1,21 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Recommended Security Tools | Strong Password Generator',
   description: 'Our top picks for password managers, VPNs, antivirus, and identity protection. Curated by the SecurePass security team.',
+  openGraph: {
+    type: 'website',
+    url: 'https://strongpasswordgenerator.dev/recommended-tools',
+    siteName: 'Strong Password Generator',
+    title: 'Recommended Security Tools | Strong Password Generator',
+    description: 'Our top picks for password managers, VPNs, antivirus, and identity protection.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Recommended Security Tools | Strong Password Generator',
+    description: 'Our top picks for password managers, VPNs, antivirus, and identity protection.',
+  },
 };
 
 const tools = [


### PR DESCRIPTION
## Summary
- Add typed Next.js metadata exports to the recommended tools and about pages.
- Extend both pages with Open Graph and Twitter Card metadata while preserving existing title and description text.

## Verification
- npm run build
- Issue body snapshot at claim: 2e06bac742884b1b

Closes #115