### PR TITLE
Add copy keyboard shortcut

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -149,6 +149,29 @@ export default function Home() {
     return () => window.clearTimeout(timer);
   }, [generatePassword]);
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const activeTag = document.activeElement?.tagName;
+
+      if (
+        event.key.toLowerCase() === 'c' &&
+        (event.metaKey || event.ctrlKey) &&
+        activeTag !== 'INPUT' &&
+        activeTag !== 'TEXTAREA' &&
+        activeTag !== 'SELECT'
+      ) {
+        event.preventDefault();
+        navigator.clipboard.writeText(password);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [password]);
+
   const optionChanged = (key: keyof PasswordOptions, value: boolean | number) => {
     setOptions(prev => ({ ...prev, [key]: value }));
   };
@@ -196,6 +219,8 @@ export default function Home() {
               🎲 Generate
             </button>
           </div>
+
+          <span className="mt-1 block text-xs text-slate-400">Press Cmd+C / Ctrl+C anywhere to copy</span>
 
           {password && (
             <div className="mb-2">


### PR DESCRIPTION
## Summary
- Add a document-level Cmd+C / Ctrl+C shortcut that copies the generated password when focus is not inside an input, textarea, or select.
- Reuse the existing copied toast state and add the shortcut hint near the copy controls.

Closes #114

## Verification
- `npm run build` passed locally.
- Issue body snapshot at claim: ad51e687af835f7a

## Notes
- Shell-based `git push` could not resolve `github.com`, so the branch update was published through the GitHub connector after local verification.