### PR TITLE
feat: add NordPass CTA to blog post

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import AffiliateCTA from '../../components/AffiliateCTA';
+import NordPassCTA from '../../components/NordPassCTA';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import postsIndex from '../../../posts/index.json';
@@ -27,6 +28,10 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://strongpasswordgene
 const bitwardenRecommendedSlugs = new Set([
   'bitwarden-setup-guide',
   'lastpass-alternatives',
+]);
+
+const nordPassRecommendedSlugs = new Set([
+  'nordpass-vs-dashlane-2026',
 ]);
 
 export async function generateStaticParams() {
@@ -142,6 +147,12 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           <p className="text-slate-500 text-base leading-relaxed mb-6 border-l-4 border-indigo-200 pl-4 italic">
             {post.excerpt}
           </p>
+
+          {nordPassRecommendedSlugs.has(post.slug) && (
+            <div className="my-6">
+              <NordPassCTA />
+            </div>
+          )}
 
           {bitwardenRecommendedSlugs.has(post.slug) && (
             <blockquote className="bg-indigo-50 border-l-4 border-indigo-300 rounded-r-xl p-4 my-6 text-sm text-indigo-900">

--- a/src/app/components/NordPassCTA.tsx
+++ b/src/app/components/NordPassCTA.tsx
@@ -1,0 +1,22 @@
+import AffiliateCTA from './AffiliateCTA';
+
+export default function NordPassCTA() {
+  return (
+    <aside className="rounded-2xl border border-indigo-100 bg-white p-5 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-wide text-indigo-500 mb-2">
+        Sponsored recommendation
+      </p>
+      <h2 className="text-lg font-bold text-slate-800 mb-2">
+        Want a simpler way to manage strong passwords?
+      </h2>
+      <p className="text-sm text-slate-600 mb-4">
+        NordPass stores unique passwords for every account, checks password health, and alerts you when data leaks put
+        accounts at risk.
+      </p>
+      <AffiliateCTA product="nordpass" />
+      <p className="text-xs text-slate-400 mt-3">
+        Affiliate disclosure: we may earn a commission if you buy through this link, at no extra cost to you.
+      </p>
+    </aside>
+  );
+}


### PR DESCRIPTION
Closes #124

## Summary
- Add a reusable `NordPassCTA` component with affiliate disclosure copy.
- Render the CTA on the `nordpass-vs-dashlane-2026` blog post without rewriting the full blog route.
- Reuse the existing `AffiliateCTA product="nordpass"` implementation.

## Verification
- Issue body snapshot at claim: `8a42517a2f26b096`
- `npm run build`

Note: local build emitted a Next.js workspace-root warning due another lockfile higher in `/Users/msarmento`; the production build completed successfully.
