### PR TITLE
a11y: add aria-labels to PassphraseGenerator controls

### DIFF
--- a/src/app/components/PassphraseGenerator.a11y.test.mjs
+++ b/src/app/components/PassphraseGenerator.a11y.test.mjs
@@ -1,0 +1,37 @@
+// Accessibility regression test for PassphraseGenerator.
+// Uses Node's built-in test runner (no new dependencies) since this repo has
+// no test framework configured. Run with: node --test src/app/components/PassphraseGenerator.a11y.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rawSource = readFileSync(join(__dirname, 'PassphraseGenerator.tsx'), 'utf8');
+// Strip JSX expression containers ({...}) so embedded arrow functions (=>) don't
+// confuse the tag-boundary regex below.
+const source = rawSource.replace(/\{[^{}]*\}/g, '{EXPR}');
+
+test('every interactive control (input, select, button) has an accessible name', () => {
+  // Split into per-element tags so each control is checked independently
+  // rather than just counting aria-label occurrences globally.
+  const elementRegex = /<(input|select|button)\b[^>]*?\/?>/gs;
+  const elements = source.match(elementRegex) || [];
+
+  assert.ok(elements.length >= 4, `expected at least 4 interactive controls, found ${elements.length}`);
+
+  for (const el of elements) {
+    const hasAriaLabel = /aria-label=/.test(el);
+    const hasAriaLabelledBy = /aria-labelledby=/.test(el);
+    assert.ok(
+      hasAriaLabel || hasAriaLabelledBy,
+      `interactive control missing an accessible name (aria-label/aria-labelledby): ${el}`
+    );
+  }
+});
+
+test('at least 3 aria-label attributes are present (up from 0 before the a11y fix)', () => {
+  const count = (source.match(/aria-label=/g) || []).length;
+  assert.ok(count >= 3, `expected >= 3 aria-label attributes, found ${count}`);
+});

--- a/src/app/components/PassphraseGenerator.tsx
+++ b/src/app/components/PassphraseGenerator.tsx
@@ -50,11 +50,15 @@ export default function PassphraseGenerator() {
           Words: {wordCount}
           <input type="range" min={3} max={8} value={wordCount}
             onChange={e => setWordCount(parseInt(e.target.value))}
+            aria-label="Number of words in passphrase"
+            aria-describedby="passphrase-word-count-value"
             className="ml-2 w-24 accent-[#00d4aa] align-middle" />
+          <span id="passphrase-word-count-value" className="sr-only">{wordCount} words selected</span>
         </label>
         <label className="text-sm text-slate-500 font-medium">
           Separator:
           <select value={separator} onChange={e => setSeparator(e.target.value)}
+            aria-label="Passphrase word separator"
             className="ml-2 text-slate-700 border border-slate-200 rounded px-2 py-1 text-sm">
             <option value="-">Hyphen  (-)</option>
             <option value=".">Dot     (.)</option>
@@ -72,11 +76,14 @@ export default function PassphraseGenerator() {
 
       <div className="flex gap-3 flex-wrap">
         <button onClick={generate}
+          aria-label="Generate passphrase"
           className="bg-[#00d4aa] hover:bg-[#00b894] text-black font-semibold px-5 py-2.5 rounded-lg text-sm transition">
           🎲 Generate Passphrase
         </button>
         {passphrase && (
           <button onClick={copy}
+            aria-label={copied ? 'Passphrase copied to clipboard' : 'Copy passphrase to clipboard'}
+            aria-describedby="passphrase-value"
             className="bg-slate-100 hover:bg-slate-200 text-slate-700 font-semibold px-5 py-2.5 rounded-lg text-sm transition">
             {copied ? '✓ Copied!' : '📋 Copy'}
           </button>
@@ -84,7 +91,7 @@ export default function PassphraseGenerator() {
       </div>
 
       {passphrase && (
-        <p className="text-xs text-slate-400">
+        <p id="passphrase-value" className="text-xs text-slate-400">
           Entropy: ~{Math.round(wordCount * Math.log2(WORDS.length))} bits · Crack time at 10B guesses/sec: centuries+
         </p>
       )}


### PR DESCRIPTION
Marcus OS migration — Task 2 (premium lane, per plan §11 Issue 1).

Fixes the a11y issue behind #156 directly instead of re-queuing to the free-builder chain, which failed 3x due to a malformed verification command (see diagnosis comment on #156), not a real scope/CI problem.

**Changes (2 files, as scoped):**
- `PassphraseGenerator.tsx`: aria-label on all 4 interactive controls (words range input, separator select, Generate button, Copy button), plus aria-describedby linking the slider/copy button to their visible value text.
- `PassphraseGenerator.a11y.test.mjs`: new dependency-free test (Node's built-in `node:test`) asserting every control has an accessible name and that >=3 aria-label attributes exist. This repo has no test framework configured, so no new dependencies were added — run via `node --test src/app/components/PassphraseGenerator.a11y.test.mjs`.

**Verified locally:** `npm run lint` ✅, `npm run build` ✅, `node --test .../PassphraseGenerator.a11y.test.mjs` ✅ (2/2 passing).

Closes #156.