### PR TITLE
a11y: announce passphrase copy confirmation

### DIFF
--- a/src/app/components/PassphraseGenerator.tsx
+++ b/src/app/components/PassphraseGenerator.tsx
@@ -81,12 +81,17 @@ export default function PassphraseGenerator() {
           🎲 Generate Passphrase
         </button>
         {passphrase && (
-          <button onClick={copy}
-            aria-label={copied ? 'Passphrase copied to clipboard' : 'Copy passphrase to clipboard'}
-            aria-describedby="passphrase-value"
-            className="bg-slate-100 hover:bg-slate-200 text-slate-700 font-semibold px-5 py-2.5 rounded-lg text-sm transition">
-            {copied ? '✓ Copied!' : '📋 Copy'}
-          </button>
+          <>
+            <button onClick={copy}
+              aria-label={copied ? 'Passphrase copied to clipboard' : 'Copy passphrase to clipboard'}
+              aria-describedby="passphrase-value"
+              className="bg-slate-100 hover:bg-slate-200 text-slate-700 font-semibold px-5 py-2.5 rounded-lg text-sm transition">
+              {copied ? '✓ Copied!' : '📋 Copy'}
+            </button>
+            <span role="status" aria-live="polite" className="sr-only">
+              {copied ? 'Passphrase copied to clipboard' : ''}
+            </span>
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Add a visually hidden polite live region after the passphrase Copy button.
- Preserve the existing button behavior, styling, and aria-label text.

Closes #162

## Verification

- Issue body snapshot at claim: `08d42303939c1264`
- Original queue: `agios:escalate-codex`
- `npm run build && npm run lint`

Notes:
- `npm ci` was run first in the clean temp checkout because dependencies were not installed locally.
- `npm ci` completed with existing engine/audit warnings.
