### PR TITLE
[codex] Fix trust page canonicals

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,9 @@ import Script from 'next/script';
 export const metadata: Metadata = {
   title: 'About | Strong Password Generator',
   description: 'Learn about StrongPasswordGenerator.dev — a free tool to generate cryptographically secure passwords and learn password security best practices.',
+  alternates: {
+    canonical: 'https://strongpasswordgenerator.dev/about',
+  },
   openGraph: {
     type: 'website',
     url: 'https://strongpasswordgenerator.dev/about',

--- a/src/app/recommended-tools/page.tsx
+++ b/src/app/recommended-tools/page.tsx
@@ -6,6 +6,9 @@ import AffiliateCTA from '../components/AffiliateCTA';
 export const metadata: Metadata = {
   title: 'Recommended Security Tools | Strong Password Generator',
   description: 'Our top picks for password managers, VPNs, antivirus, and identity protection. Curated by the SecurePass security team.',
+  alternates: {
+    canonical: 'https://strongpasswordgenerator.dev/recommended-tools',
+  },
   openGraph: {
     type: 'website',
     url: 'https://strongpasswordgenerator.dev/recommended-tools',


### PR DESCRIPTION
## Summary
- add page-specific canonical URLs for /about and /recommended-tools
- keep trust and revenue-support pages indexable as distinct pages

## Validation
- npm run lint
- npm run build

Closes #171