### PR TITLE
Improve SPG trust metadata and affiliate CTAs

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -28,6 +28,7 @@ interface PostData {
 }
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://strongpasswordgenerator.dev';
+const OG_IMAGE_URL = `${SITE_URL}/opengraph-image`;
 
 const bitwardenRecommendedSlugs = new Set([
   'bitwarden-setup-guide',
@@ -36,7 +37,35 @@ const bitwardenRecommendedSlugs = new Set([
 
 const nordPassRecommendedSlugs = new Set([
   'nordpass-vs-dashlane-2026',
+  'nordpass-review-2026',
+  'free-vs-paid-password-managers-2026',
+  'password-manager-vs-browser-autofill',
+  'how-to-create-strong-password',
 ]);
+
+function getAffiliateProduct(post: PostData): 'bitwarden' | 'nordpass' | 'nordvpn' | 'nordprotect' {
+  const topicText = `${post.slug} ${post.category} ${post.tags.join(' ')} ${post.title}`.toLowerCase();
+
+  if (topicText.includes('vpn') || topicText.includes('wifi') || topicText.includes('remote work')) {
+    return 'nordvpn';
+  }
+
+  if (
+    topicText.includes('identity') ||
+    topicText.includes('breach') ||
+    topicText.includes('dark web') ||
+    topicText.includes('credit') ||
+    topicText.includes('hacked')
+  ) {
+    return 'nordprotect';
+  }
+
+  if (topicText.includes('nordpass') || topicText.includes('password manager') || topicText.includes('password')) {
+    return 'nordpass';
+  }
+
+  return 'bitwarden';
+}
 
 export async function generateStaticParams() {
   return allPosts.map((post) => ({ slug: post.slug }));
@@ -66,12 +95,21 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       siteName: 'Strong Password Generator',
       publishedTime: post.date,
       tags: post.tags,
+      images: [
+        {
+          url: OG_IMAGE_URL,
+          width: 1200,
+          height: 630,
+          alt: 'Strong Password Generator security tools',
+        },
+      ],
     },
     twitter: {
       card: 'summary_large_image',
       site: '@strongpwdgen',
       title,
       description,
+      images: [OG_IMAGE_URL],
     },
   };
 }
@@ -89,6 +127,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   const relatedPosts: PostMeta[] = getRelatedPosts(post);
   const hub = getHubForPost(post);
   const faqItems = extractFaqItems(post.content);
+  const affiliateProduct = getAffiliateProduct(post);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
@@ -101,7 +140,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
             "headline": post.title,
             "description": description,
             "image": [
-              `${SITE_URL}/images/${post.slug}.jpg`,
+              OG_IMAGE_URL,
             ],
             "datePublished": post.date,
             "dateModified": post.date,
@@ -250,7 +289,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
         </div>
 
         <div className="mt-8">
-          <AffiliateCTA product="bitwarden" />
+          <AffiliateCTA product={affiliateProduct} />
         </div>
 
         <div className="mt-4 text-center">

--- a/src/app/components/AffiliateCTA.tsx
+++ b/src/app/components/AffiliateCTA.tsx
@@ -8,10 +8,22 @@ const affiliates = {
     description: "Open-source password manager trusted by millions. Free forever.",
   },
   nordpass: {
-    url: process.env.NEXT_PUBLIC_NORDPASS_AFFILIATE_URL ?? "https://nordpass.com",
+    url: process.env.NEXT_PUBLIC_NORDPASS_AFFILIATE_URL ?? "https://www.kqzyfj.com/click-101754888-17262576",
     cta: "Try NordPass",
     badge: "Best value",
     description: "Simple, fast, and secure. Made by the team behind NordVPN.",
+  },
+  nordvpn: {
+    url: process.env.NEXT_PUBLIC_NORDVPN_AFFILIATE_URL ?? "https://www.awin1.com/cread.php?awinmid=15132&awinaffid=2892161",
+    cta: "Try NordVPN",
+    badge: "Best for public Wi-Fi",
+    description: "Encrypt traffic on public networks and add threat protection beyond passwords.",
+  },
+  nordprotect: {
+    url: process.env.NEXT_PUBLIC_NORDPROTECT_AFFILIATE_URL ?? "https://www.awin1.com/cread.php?awinmid=123620&awinaffid=2892161",
+    cta: "Try NordProtect",
+    badge: "Identity protection",
+    description: "Monitor breach exposure and get alerts before leaked credentials turn into account takeover.",
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,11 +16,20 @@ export const metadata: Metadata = {
     url: "https://strongpasswordgenerator.dev",
     siteName: "Strong Password Generator",
     type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Strong Password Generator security tools",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "Strong Password Generator | Free Security Suite",
     description: "Generate cryptographically secure passwords with advanced security analysis. Free, no signup required.",
+    images: ["/opengraph-image"],
   },
 };
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,54 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "Strong Password Generator security tools";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          alignItems: "center",
+          background: "linear-gradient(135deg, #f8fafc 0%, #dbeafe 48%, #e0e7ff 100%)",
+          color: "#0f172a",
+          display: "flex",
+          flexDirection: "column",
+          fontFamily: "Arial, sans-serif",
+          height: "100%",
+          justifyContent: "center",
+          padding: "72px",
+          width: "100%",
+        }}
+      >
+        <div
+          style={{
+            alignItems: "center",
+            background: "linear-gradient(135deg, #6366f1, #9333ea)",
+            borderRadius: "36px",
+            color: "white",
+            display: "flex",
+            fontSize: 72,
+            fontWeight: 800,
+            height: 132,
+            justifyContent: "center",
+            marginBottom: 44,
+            width: 132,
+          }}
+        >
+          🔐
+        </div>
+        <div style={{ fontSize: 70, fontWeight: 800, letterSpacing: 0, lineHeight: 1.05, textAlign: "center" }}>
+          Strong Password Generator
+        </div>
+        <div style={{ color: "#475569", fontSize: 32, lineHeight: 1.35, marginTop: 28, textAlign: "center" }}>
+          Free password tools, security guides, and practical account protection.
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -40,6 +40,12 @@ const staticRoutes: MetadataRoute.Sitemap = [
     changeFrequency: 'weekly',
     priority: 0.5,
   },
+  {
+    url: `${BASE_URL}/editorial-policy`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly',
+    priority: 0.5,
+  },
 ];
 
 export default function sitemap(): MetadataRoute.Sitemap {


### PR DESCRIPTION
## Summary
- add a real site-wide Open Graph image route and wire it into metadata
- replace broken blog Article JSON-LD image URLs with the generated OG image
- add editorial policy to the sitemap
- route end-of-post affiliate CTAs to NordPass, NordVPN, NordProtect, or Bitwarden based on topic intent

Closes #153
Closes #180

## Validation
- npm run lint
- npm run build