### PR TITLE
[AGIOS] seo: add Open Graph metadata to contact, privacy, and editorial-policy pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,6 +3,14 @@ import Link from 'next/link';
 export const metadata = {
   title: 'Contact | Strong Password Generator',
   description: 'Get in touch with the StrongPasswordGenerator.dev team.',
+  openGraph: {
+    title: 'Contact | Strong Password Generator',
+    description: 'Get in touch with the StrongPasswordGenerator.dev team.',
+    url: 'https://strongpasswordgenerator.dev/contact',
+    siteName: 'Strong Password Generator',
+    type: 'website',
+    images: [{ url: '/og-image.svg' }],
+  },
 };
 
 export default function ContactPage() {

--- a/src/app/editorial-policy/page.tsx
+++ b/src/app/editorial-policy/page.tsx
@@ -7,6 +7,14 @@ export const metadata: Metadata = {
   alternates: {
     canonical: 'https://strongpasswordgenerator.dev/editorial-policy',
   },
+  openGraph: {
+    title: 'Editorial Policy | Strong Password Generator',
+    description: 'How StrongPasswordGenerator.dev researches, reviews, and monetizes password security guides and tool recommendations.',
+    url: 'https://strongpasswordgenerator.dev/editorial-policy',
+    siteName: 'Strong Password Generator',
+    type: 'website',
+    images: [{ url: '/og-image.svg' }],
+  },
 };
 
 export default function EditorialPolicyPage() {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -3,6 +3,14 @@ import Link from 'next/link';
 export const metadata = {
   title: 'Privacy Policy | Strong Password Generator',
   description: 'Privacy policy for StrongPasswordGenerator.dev — we collect minimal data and never see your generated passwords.',
+  openGraph: {
+    title: 'Privacy Policy | Strong Password Generator',
+    description: 'Privacy policy for StrongPasswordGenerator.dev — we collect minimal data and never see your generated passwords.',
+    url: 'https://strongpasswordgenerator.dev/privacy',
+    siteName: 'Strong Password Generator',
+    type: 'website',
+    images: [{ url: '/og-image.svg' }],
+  },
 };
 
 export default function PrivacyPage() {


### PR DESCRIPTION
Closes #191

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `17.23` seconds
- Files changed: src/app/contact/page.tsx, src/app/editorial-policy/page.tsx, src/app/privacy/page.tsx

## Verification
Router verification completed before opening this PR.