### PR TITLE
[AGIOS] content: Add 'Related Posts' section to Password Managers topic hub

### DIFF
--- a/src/app/blog/password-managers/page.tsx
+++ b/src/app/blog/password-managers/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import TopicHubPage from '../TopicHubPage';
 import { topicHubs } from '../../../lib/posts';
 import NordPassCTA from '../../components/NordPassCTA';
+import RelatedPostsList from '../../components/RelatedPostsList';
+import { getHubPosts } from '../../../lib/posts';
 
 const hub = topicHubs.find((item) => item.slug === 'password-managers')!;
 
@@ -17,6 +19,7 @@ export default function PasswordManagersHub() {
   return (
     <>
       <NordPassCTA />
+      <RelatedPostsList posts={getHubPosts(hub)} title="More on Password Managers" />
       <TopicHubPage hub={hub} />
     </>
   );


### PR DESCRIPTION
Closes #240

## Summary
AGIOS builder router completed implementation with `mistral`.

## Builder
- Status: `success`
- Duration: `2.57` seconds
- Files changed: src/app/blog/password-managers/page.tsx

## Verification
````shell
npm run build
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.9s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/86) ...
  Generating static pages using 3 workers (21/86) 
  Generating static pages using 3 workers (42/86) 
  Generating static pages using 3 workers (64/86) 
✓ Generating static pages using 3 workers (86/86) in 1154.2ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/app/blog/password-managers/page.tsx, src/app/components/RelatedPostsList.tsx, src/lib/posts.ts
- Blocked paths: .github/, .agios/, .env
- Risk level: LOW
- Auto-merge allowed: True