### PR TITLE
[AGIOS] seo: add OpenGraph and Twitter Card metadata to password-managers and password-security hub pages

### DIFF
--- a/src/app/blog/password-managers/page.tsx
+++ b/src/app/blog/password-managers/page.tsx
@@ -11,6 +11,18 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/blog/password-managers',
   },
+  openGraph: {
+    title: `${hub.title} | Strong Password Generator`,
+    description: 'Learn about the best password managers, how they work, and why you should use one to secure your online accounts.',
+    url: 'https://strongpasswordgenerator.dev/blog/password-managers',
+    siteName: 'Strong Password Generator',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${hub.title} | Strong Password Generator`,
+    description: 'Learn about the best password managers, how they work, and why you should use one to secure your online accounts.',
+  },
 };
 
 export default function PasswordManagersHub() {

--- a/src/app/blog/password-security/page.tsx
+++ b/src/app/blog/password-security/page.tsx
@@ -10,6 +10,18 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/blog/password-security',
   },
+  openGraph: {
+    title: `${hub.title} | Strong Password Generator`,
+    description: 'Discover essential tips and strategies for creating strong passwords, protecting your accounts, and improving your overall password security.',
+    url: 'https://strongpasswordgenerator.dev/blog/password-security',
+    siteName: 'Strong Password Generator',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${hub.title} | Strong Password Generator`,
+    description: 'Discover essential tips and strategies for creating strong passwords, protecting your accounts, and improving your overall password security.',
+  },
 };
 
 export default function PasswordSecurityHub() {


### PR DESCRIPTION
Closes #262

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `9.84` seconds
- Files changed: src/app/blog/password-managers/page.tsx, src/app/blog/password-security/page.tsx

## Verification
````bash
npm run build && npm run lint
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.8s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/86) ...
  Generating static pages using 3 workers (21/86) 
  Generating static pages using 3 workers (42/86) 
  Generating static pages using 3 workers (64/86) 
✓ Generating static pages using 3 workers (86/86) in 1086.6ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)


> strongpasswordgenerator@0.1.0 lint
> eslint


/home/runner/work/strongpasswordgenerator.dev/strongpasswordgenerator.dev/target/src/app/components/PassphraseGenerator.tsx
  39:9  warning  The 'copy' function makes the dependencies of useEffect Hook (at line 58) change on every render. To fix this, wrap the definition of 'copy' in its own useCallback() Hook  react-hooks/exhaustive-deps

✖ 1 problem (0 errors, 1 warning)
```

## Issue body snapshot
- Allowed paths: src/app/blog/password-managers/page.tsx, src/app/blog/password-security/page.tsx
- Blocked paths: .github/**, .agios/**, *.env*
- Risk level: LOW
- Auto-merge allowed: True