### PR TITLE
[AGIOS] content: Add a 'Key Takeaways' section to the /editorial-policy page

### DIFF
--- a/src/app/editorial-policy/page.tsx
+++ b/src/app/editorial-policy/page.tsx
@@ -95,6 +95,16 @@ export default function EditorialPolicyPage() {
           <p className="text-slate-600 leading-relaxed mb-6">
             StrongPasswordGenerator.dev publishes practical password security guidance for everyday users. Our goal is to help readers make safer account-security decisions without hype, fear tactics, or unnecessary complexity.
           </p>
+          <section className="bg-blue-50 p-6 rounded-2xl border border-blue-100 mb-6">
+            <h2 className="text-xl font-bold text-slate-800 mb-3">Key Takeaways</h2>
+            <ul className="list-disc list-inside space-y-2 text-slate-700">
+              <li>Our content is based on thorough research, including vendor documentation and security best practices, prioritizing actionable advice for users.</li>
+              <li>Tool recommendations are chosen for their security, reputation, and usability, not solely for affiliate commissions.</li>
+              <li>We frequently review and update content, especially for commercially important pages, to ensure accuracy and relevance.</li>
+              <li>Some links are affiliate links, which may earn us a commission at no extra cost to you, helping to keep our resources free.</li>
+              <li>We avoid scare tactics, fake urgency, or content published solely for monetization, focusing instead on genuine value.</li>
+            </ul>
+          </section>
 
           <div className="space-y-7 text-slate-600 leading-relaxed">
             <section>


### PR DESCRIPTION
Closes #274

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `8.44` seconds
- Files changed: src/app/editorial-policy/page.tsx

## Verification
````shell
npm run build
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 3.1s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/86) ...
  Generating static pages using 3 workers (21/86) 
  Generating static pages using 3 workers (42/86) 
  Generating static pages using 3 workers (64/86) 
✓ Generating static pages using 3 workers (86/86) in 1225.2ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/app/editorial-policy/page.tsx
- Blocked paths: .github/, .agios/, .env
- Risk level: LOW
- Auto-merge allowed: True