### PR TITLE
[AGIOS] content/seo: Add FAQ section with JSON-LD to Editorial Policy page

### DIFF
--- a/src/app/editorial-policy/page.tsx
+++ b/src/app/editorial-policy/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import Script from 'next/script';
 
 export const metadata: Metadata = {
   title: 'Editorial Policy | Strong Password Generator',
@@ -20,7 +21,8 @@ export const metadata: Metadata = {
 export default function EditorialPolicyPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
-      <script
+      <Script
+        id="faq-schema"
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify({
@@ -78,6 +80,7 @@ export default function EditorialPolicyPage() {
             ]
           })
         }}
+        strategy="beforeInteractive"
       />
       <header className="bg-white/80 backdrop-blur-md border-b border-slate-200/50 py-4 px-6 sticky top-0 z-10">
         <div className="max-w-3xl mx-auto flex justify-between items-center">
@@ -149,6 +152,36 @@ export default function EditorialPolicyPage() {
               </p>
             </section>
           </div>
+
+          <section className="mt-8">
+            <h2 className="text-2xl font-bold text-slate-800 mb-4">Frequently Asked Questions</h2>
+            <div className="space-y-6">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: How does StrongPasswordGenerator.dev research articles?</h3>
+                <p className="text-slate-600 leading-relaxed">A: Security guides are based on vendor documentation, public security guidance, breach-response best practices, and hands-on evaluation where applicable. We prioritize advice that a reader can apply immediately: unique passwords, password managers, two-factor authentication, passkeys, account recovery, and breach monitoring.</p>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: How does StrongPasswordGenerator.dev review recommendations?</h3>
+                <p className="text-slate-600 leading-relaxed">A: Tool recommendations consider security model, reputation, pricing, ease of use, cross-device support, export options, and fit for the reader&apos;s situation. We avoid recommending tools solely because they pay commissions.</p>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: How often does StrongPasswordGenerator.dev update content?</h3>
+                <p className="text-slate-600 leading-relaxed">A: We review commercially important pages more often than evergreen explainers, especially when pricing, feature limits, or vendor positioning changes. When a recommendation meaningfully changes, we update the page rather than quietly redirecting readers to a different product.</p>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: Does StrongPasswordGenerator.dev use affiliate links?</h3>
+                <p className="text-slate-600 leading-relaxed">A: Some outbound links are affiliate links. If you buy through those links, we may earn a commission at no extra cost to you. Affiliate relationships help keep the generator and guides free, but they do not determine whether a product is included or how it is described.</p>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: What kind of content does StrongPasswordGenerator.dev avoid publishing?</h3>
+                <p className="text-slate-600 leading-relaxed">A: We avoid publishing filler pages, exaggerated scare tactics, fake urgency, or recommendations that exist only to monetize search traffic. If a product is not a good fit for the reader&apos;s situation, we would rather point them to a different guide than force a weak recommendation.</p>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: How can I report corrections or updates to StrongPasswordGenerator.dev?</h3>
+                <p className="text-slate-600 leading-relaxed">A: Security advice changes as products, threats, and platform defaults change. If you spot an outdated claim, broken link, or factual issue, please contact us so we can review and update the page.</p>
+              </div>
+            </div>
+          </section>
 
           <div className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 p-5">
             <h2 className="text-lg font-bold text-slate-800 mb-2">Need to Flag an Issue?</h2>


### PR DESCRIPTION
Closes #278

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `32.1` seconds
- Files changed: src/app/editorial-policy/page.tsx

## Verification
````shell
npm run build
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.5s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/86) ...
  Generating static pages using 3 workers (21/86) 
  Generating static pages using 3 workers (42/86) 
  Generating static pages using 3 workers (64/86) 
✓ Generating static pages using 3 workers (86/86) in 923.2ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/app/editorial-policy/page.tsx
- Blocked paths: .github/, .agios/, .env
- Risk level: LOW
- Auto-merge allowed: True