### PR TITLE
[AGIOS] ux: Add common weak-pattern warning to Password Checker

### DIFF
--- a/src/app/components/PasswordChecker.tsx
+++ b/src/app/components/PasswordChecker.tsx
@@ -40,6 +40,86 @@ function calculateStrength(pwd: string): { score: number; label: string } {
   return { score: 5, label: 'Very Strong' };
 }
 
+function normalizeForLeetspeak(pwd: string): string[] {
+  let normalizedPwd = pwd.toLowerCase();
+  normalizedPwd = normalizedPwd.replace(/@/g, 'a');
+  normalizedPwd = normalizedPwd.replace(/4/g, 'a');
+  normalizedPwd = normalizedPwd.replace(/3/g, 'e');
+  normalizedPwd = normalizedPwd.replace(/0/g, 'o');
+  normalizedPwd = normalizedPwd.replace(/\$/g, 's');
+
+  // Handle 1 -> i/l. This will create two versions of the normalized password if '1' is present.
+  const normalizedVersions: string[] = [];
+  if (normalizedPwd.includes('1')) {
+    normalizedVersions.push(normalizedPwd.replace(/1/g, 'i'));
+    normalizedVersions.push(normalizedPwd.replace(/1/g, 'l'));
+  } else {
+    normalizedVersions.push(normalizedPwd);
+  }
+
+  return normalizedVersions;
+}
+
+function detectWeakPatterns(pwd: string): string[] {
+  const warnings: string[] = [];
+  if (pwd.length === 0) return warnings;
+
+  const lowerPwd = pwd.toLowerCase();
+
+  // 1. Sequential characters of 4+
+  const sequences = [
+    'abcdefghijklmnopqrstuvwxyz',
+    'zyxwuvtsrqponmlkjihgfedcba',
+    '0123456789',
+    '9876543210',
+    // QWERTY keyboard rows
+    'qwertyuiop', 'poiuytrewq',
+    'asdfghjkl', 'lkjhgfdsa',
+    'zxcvbnm', 'mnbvcxz',
+  ];
+
+  let sequentialWarningAdded = false;
+  for (const seq of sequences) {
+    for (let i = 0; i <= seq.length - 4; i++) {
+      const subSeq = seq.substring(i, i + 4);
+      if (lowerPwd.includes(subSeq)) {
+        warnings.push('Contains sequential characters (e.g., "abcd", "1234")');
+        sequentialWarningAdded = true;
+        break;
+      }
+    }
+    if (sequentialWarningAdded) break;
+  }
+
+  // 2. 4+ repeated identical characters in a row
+  if (/(.)\1{3,}/.test(pwd)) {
+    warnings.push('Contains 4 or more repeated characters (e.g., "aaaa", "1111")');
+  }
+
+  // 3. Common base words with leetspeak substitutions
+  const weakWords = [
+    'password', 'qwerty', 'letmein', 'dragon', 'monkey', 'welcome', 'admin',
+    '123456', 'iloveyou', 'secret', 'master', 'access', 'default', 'test', 'hello'
+  ];
+
+  const normalizedPasswords = normalizeForLeetspeak(pwd);
+
+  let weakWordWarningAdded = false;
+  for (const weakWord of weakWords) {
+    for (const normalizedPwd of normalizedPasswords) {
+      if (normalizedPwd.includes(weakWord)) {
+        warnings.push('Contains a common weak pattern or dictionary word');
+        weakWordWarningAdded = true;
+        break;
+      }
+    }
+    if (weakWordWarningAdded) break;
+  }
+
+  // Remove duplicates if any check triggers multiple times
+  return Array.from(new Set(warnings));
+}
+
 export default function PasswordChecker() {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
@@ -47,6 +127,7 @@ export default function PasswordChecker() {
   const [strengthLabel, setStrengthLabel] = useState('');
   const [crackTime, setCrackTime] = useState('');
   const [entropy, setEntropy] = useState(0);
+  const [weakPatterns, setWeakPatterns] = useState<string[]>([]);
 
   const getStrengthColor = useCallback(() => {
     const colors = ['#ff6b6b', '#ff6b6b', '#feca57', '#feca57', '#26de81', '#26de81'];
@@ -56,12 +137,14 @@ export default function PasswordChecker() {
   const updatePassword = (nextPassword: string) => {
     const nextEntropy = calculateEntropy(nextPassword);
     const nextStrength = calculateStrength(nextPassword);
+    const detectedWeakPatterns = detectWeakPatterns(nextPassword);
 
     setPassword(nextPassword);
     setEntropy(nextEntropy);
     setStrengthScore(nextStrength.score);
     setStrengthLabel(nextStrength.label);
     setCrackTime(estimateCrackTime(nextEntropy));
+    setWeakPatterns(detectedWeakPatterns);
   };
 
   return (
@@ -115,6 +198,17 @@ export default function PasswordChecker() {
               Estimated crack time: <span className="text-slate-700">{crackTime}</span>
             </div>
           </div>
+
+          {weakPatterns.length > 0 && (
+            <div className="mt-4 space-y-2">
+              {weakPatterns.map((warning, index) => (
+                <div key={index} className="flex items-center text-sm text-red-600 font-medium">
+                  <span className="mr-2 text-lg">⚠️</span>
+                  <span>{warning}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #287

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `30.04` seconds
- Files changed: src/app/components/PasswordChecker.tsx

## Verification
````bash
npm run build && npm run lint
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 3.0s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/86) ...
  Generating static pages using 3 workers (21/86) 
  Generating static pages using 3 workers (42/86) 
  Generating static pages using 3 workers (64/86) 
✓ Generating static pages using 3 workers (86/86) in 1231.4ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)


> strongpasswordgenerator@0.1.0 lint
> eslint


/home/runner/work/strongpasswordgenerator.dev/strongpasswordgenerator.dev/target/src/app/components/PassphraseGenerator.tsx
  39:9  warning  The 'copy' function makes the dependencies of useEffect Hook (at line 58) change on every render. To fix this, wrap the definition of 'copy' in its own useCallback() Hook  react-hooks/exhaustive-deps

✖ 1 problem (0 errors, 1 warning)
```

## Issue body snapshot
- Allowed paths: src/app/components/PasswordChecker.tsx
- Blocked paths: .github/**, .agios/**, *.env*
- Risk level: LOW
- Auto-merge allowed: True