### PR TITLE
[AGIOS] content: Add 'Key Takeaways' section to /privacy page

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -74,6 +74,16 @@ export default function PrivacyPage() {
             </section>
 
             <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Key Takeaways</h2>
+              <ul className="list-disc list-inside space-y-2 text-slate-600 leading-relaxed">
+                <li><strong>Your Passwords are Private:</strong> All password generation happens directly in your browser and is never sent to our servers.</li>
+                <li><strong>Minimal Data Collection:</strong> We collect non-identifying analytics data (like page views) but no personal information unless you contact us directly.</li>
+                <li><strong>Local Storage for Preferences:</strong> Your password history and generator settings are saved only on your device using browser local storage.</li>
+                <li><strong>Transparency on Third-Parties:</strong> We use services like Google Analytics and AdSense, and some links are affiliates, all disclosed in detail.</li>
+              </ul>
+            </section>
+
+            <section>
               <h2 className="text-xl font-bold text-slate-800 mb-3">Password Generation</h2>
               <p>All passwords are generated client-side using your browser&apos;s <code className="bg-slate-100 px-1 rounded text-indigo-700">crypto.getRandomValues()</code> API. Generated passwords are never transmitted to our servers, never logged, and never stored anywhere except optionally in your own browser&apos;s localStorage.</p>
             </section>


### PR DESCRIPTION
Closes #283

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `4.08` seconds
- Files changed: src/app/privacy/page.tsx

## Verification
````shell
npm run build
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 3.3s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/86) ...
  Generating static pages using 3 workers (21/86) 
  Generating static pages using 3 workers (42/86) 
  Generating static pages using 3 workers (64/86) 
✓ Generating static pages using 3 workers (86/86) in 1299.1ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/app/privacy/page.tsx
- Blocked paths: .github/, .agios/, .env
- Risk level: LOW
- Auto-merge allowed: True