### PR TITLE
Add password safety checklist page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -339,6 +339,7 @@ function PasswordGeneratorPage() {
         <div className="max-w-3xl mx-auto flex justify-between items-center">
           <div className="flex items-center gap-3"><div className="w-10 h-10 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg"><svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" /></svg></div><h1 className="text-xl font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">SecurePass</h1></div>
           <div className="flex items-center gap-4">
+            <Link href="/password-safety-checklist" className="text-slate-500 hover:text-indigo-600 text-sm font-medium hidden sm:block">Checklist</Link>
             <a href="/recommended-tools" className="text-slate-500 hover:text-indigo-600 text-sm font-medium hidden sm:block">🛡️ Tools</a>
             <Link href="/blog" className="text-slate-500 hover:text-indigo-600 text-sm font-medium">Security Blog →</Link>
           </div>
@@ -513,6 +514,12 @@ function PasswordGeneratorPage() {
               </div>
             ))}
           </div>
+          <div className="mt-5 rounded-2xl border border-indigo-100 bg-indigo-50 p-4">
+            <h3 className="font-semibold text-slate-800 mb-1">Need a step-by-step account security plan?</h3>
+            <p className="text-sm text-slate-600">
+              Use the <Link href="/password-safety-checklist" className="text-indigo-600 underline hover:text-indigo-800">password safety checklist</Link> to prioritize unique passwords, 2FA, recovery codes, and breach cleanup.
+            </p>
+          </div>
         </div>
 
         {/* What is Password Entropy */}
@@ -609,6 +616,7 @@ function PasswordGeneratorPage() {
       <footer className="text-center py-8 text-slate-500 text-sm border-t border-slate-200 mt-4">
         <div className="flex justify-center gap-6 mb-3 flex-wrap">
           <Link href="/blog" className="hover:text-indigo-600">Security Blog</Link>
+          <Link href="/password-safety-checklist" className="hover:text-indigo-600">Safety Checklist</Link>
           <a href="/recommended-tools" className="hover:text-indigo-600">Recommended Tools</a>
           <a href="/about" className="hover:text-indigo-600">About</a>
           <a href="/privacy" className="hover:text-indigo-600">Privacy Policy</a>

--- a/src/app/password-safety-checklist/page.tsx
+++ b/src/app/password-safety-checklist/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Password Safety Checklist | Strong Password Generator',
+  description: 'A practical password safety checklist: generate strong passwords, store them safely, turn on 2FA, and recover after a breach.',
+  alternates: {
+    canonical: 'https://strongpasswordgenerator.dev/password-safety-checklist',
+  },
+  openGraph: {
+    title: 'Password Safety Checklist | Strong Password Generator',
+    description: 'A practical password safety checklist for everyday account security.',
+    url: 'https://strongpasswordgenerator.dev/password-safety-checklist',
+    siteName: 'Strong Password Generator',
+    type: 'article',
+  },
+};
+
+const checklist = [
+  {
+    title: 'Use a unique password for every important account',
+    body: 'Reuse is the biggest everyday risk. If one site is breached, attackers try the same email and password everywhere else.',
+  },
+  {
+    title: 'Make generated passwords long enough',
+    body: 'For most accounts, use at least 16 characters. For financial, email, cloud storage, and admin accounts, use 20 or more.',
+  },
+  {
+    title: 'Store passwords in a password manager',
+    body: 'A password manager lets you use strong, unique passwords without memorizing them. It also reduces the temptation to reuse easy passwords.',
+  },
+  {
+    title: 'Turn on two-factor authentication',
+    body: 'Use an authenticator app or hardware security key when possible. SMS is better than nothing, but app-based 2FA is usually stronger.',
+  },
+  {
+    title: 'Replace breached or reused passwords first',
+    body: 'Do not rotate everything randomly. Prioritize email, banking, password manager, cloud storage, social accounts, and any reused passwords.',
+  },
+  {
+    title: 'Keep recovery options current',
+    body: 'Check backup email addresses, phone numbers, recovery codes, and trusted devices before you urgently need them.',
+  },
+];
+
+export default function PasswordSafetyChecklistPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
+      <header className="bg-white/80 backdrop-blur-md border-b border-slate-200/50 py-4 px-6 sticky top-0 z-10">
+        <div className="max-w-3xl mx-auto flex justify-between items-center">
+          <Link href="/" className="text-xl font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
+            SecurePass
+          </Link>
+          <Link href="/blog" className="text-sm text-indigo-600 hover:text-indigo-800 font-medium">Security Blog</Link>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto p-6">
+        <article className="bg-white rounded-3xl shadow-xl shadow-slate-200/50 p-8 border border-slate-100">
+          <p className="text-sm font-semibold uppercase tracking-wide text-indigo-600 mb-2">Account security basics</p>
+          <h1 className="text-3xl font-bold text-slate-800 mb-4">Password Safety Checklist</h1>
+          <p className="text-slate-600 leading-relaxed mb-6">
+            A strong password generator is useful, but it is only one part of account security. Use this checklist to create better passwords, store them safely, and decide what to fix first after a breach or security scare.
+          </p>
+
+          <div className="space-y-4">
+            {checklist.map((item, index) => (
+              <section key={item.title} className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
+                <div className="flex gap-4">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-sm font-bold text-white">{index + 1}</span>
+                  <div>
+                    <h2 className="text-lg font-bold text-slate-800 mb-1">{item.title}</h2>
+                    <p className="text-slate-600 leading-relaxed m-0">{item.body}</p>
+                  </div>
+                </div>
+              </section>
+            ))}
+          </div>
+
+          <section className="mt-8 rounded-2xl border border-indigo-200 bg-indigo-50 p-5">
+            <h2 className="text-xl font-bold text-slate-800 mb-2">What to do after a breach</h2>
+            <p className="text-slate-600 leading-relaxed mb-3">
+              If a service tells you your account was affected, change that password immediately and check whether you reused it elsewhere. Then turn on 2FA and review recent account activity.
+            </p>
+            <p className="text-slate-600 leading-relaxed m-0">
+              Start by generating a fresh password on the <Link href="/" className="text-indigo-600 hover:underline">main generator</Link>, then store it in your password manager before logging out of the breached account.
+            </p>
+          </section>
+
+          <section className="mt-8 grid gap-4 md:grid-cols-2">
+            <Link href="/blog/how-to-create-strong-password" className="rounded-2xl border border-slate-200 p-5 hover:border-indigo-300 transition">
+              <h2 className="text-lg font-bold text-slate-800 mb-1">Learn the basics</h2>
+              <p className="text-sm text-slate-600 leading-relaxed">Read the guide to creating strong passwords that are hard to crack and easy to manage.</p>
+            </Link>
+            <Link href="/recommended-tools" className="rounded-2xl border border-slate-200 p-5 hover:border-indigo-300 transition">
+              <h2 className="text-lg font-bold text-slate-800 mb-1">Choose safer tools</h2>
+              <p className="text-sm text-slate-600 leading-relaxed">Compare password managers, VPNs, and account-security tools without chasing hype.</p>
+            </Link>
+          </section>
+        </article>
+      </main>
+
+      <footer className="max-w-3xl mx-auto px-6 py-8 mt-8 border-t border-slate-200 text-center text-sm text-slate-400">
+        <div className="flex justify-center gap-6 mb-3 flex-wrap">
+          <Link href="/" className="hover:text-indigo-600">Home</Link>
+          <Link href="/blog" className="hover:text-indigo-600">Blog</Link>
+          <Link href="/about" className="hover:text-indigo-600">About</Link>
+          <Link href="/privacy" className="hover:text-indigo-600">Privacy</Link>
+          <Link href="/editorial-policy" className="hover:text-indigo-600">Editorial Policy</Link>
+        </div>
+        <p>&copy; 2026 StrongPasswordGenerator.dev</p>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -23,6 +23,12 @@ const staticRoutes: MetadataRoute.Sitemap = [
     priority: 0.9,
   },
   {
+    url: `${BASE_URL}/password-safety-checklist`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly',
+    priority: 0.85,
+  },
+  {
     url: `${BASE_URL}/blog/password-managers`,
     lastModified: new Date(),
     changeFrequency: 'monthly',


### PR DESCRIPTION
## Summary
- Adds a password safety checklist page with practical account-security guidance.
- Links the checklist from the generator header, security tips area, and footer.
- Adds the checklist route to the sitemap.

## Verification
- npm ci
- npm run build

## AdSense note
- This adds a useful evergreen trust/content page before the next AdSense submission push.
- Next manual step after deploy: confirm AdSense sees ads.txt and the sitemap includes this page.

Closes #332
