### PR TITLE
Add AdSense readiness checklist and smoke check

### DIFF
--- a/docs/ADSENSE_READINESS.md
+++ b/docs/ADSENSE_READINESS.md
@@ -1,0 +1,35 @@
+# AdSense Readiness Checklist
+
+Use this checklist before requesting or re-requesting AdSense review for strongpasswordgenerator.dev.
+
+## Required Site Checks
+
+- `https://strongpasswordgenerator.dev/ads.txt` returns HTTP 200.
+- `ads.txt` contains `google.com, pub-6175161566333696, DIRECT, f08c47fec0942fa0`.
+- `https://strongpasswordgenerator.dev/sitemap.xml` returns HTTP 200.
+- The sitemap includes `/password-safety-checklist`.
+- The homepage links to `/password-safety-checklist`.
+- Core trust pages are present: `/about`, `/contact`, `/privacy`, `/editorial-policy`.
+- Optional next trust-page improvement: add `/terms` and include it in this checklist after it is merged.
+- A production build passes with `npm run build`.
+- The post-deploy smoke check passes with `npm run check:adsense`.
+
+## AdSense Console Flow
+
+1. In AdSense, open **Sites**.
+2. Click `strongpasswordgenerator.dev`.
+3. If `Ads.txt status` is `Not found`, click **Check for updates**.
+4. Do not request review until `Ads.txt status` is `Authorized`.
+5. After `Authorized`, confirm the sitemap and checklist page are live, then request review.
+
+## Vercel Deployment Notes
+
+- Vercel project: `strongpasswordgenerator`.
+- Production domain: `strongpasswordgenerator.dev`.
+- Manual production deploy fallback:
+
+```bash
+npx vercel@latest --prod --yes --token "$VERCEL_TOKEN" --name strongpasswordgenerator
+```
+
+If a Vercel deploy reports `UNKNOWN`, run `npm run build` and `npm run check:adsense` against the production domain before retrying. Keep Vercel tokens and pulled environment files out of git.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "check:adsense": "node scripts/check-adsense-readiness.mjs"
   },
   "dependencies": {
     "next": "16.1.6",

--- a/scripts/check-adsense-readiness.mjs
+++ b/scripts/check-adsense-readiness.mjs
@@ -1,0 +1,79 @@
+import { access, readFile } from 'node:fs/promises';
+
+const BASE_URL = (process.env.BASE_URL || 'https://strongpasswordgenerator.dev').replace(/\/$/, '');
+const ADS_LINE = 'google.com, pub-6175161566333696, DIRECT, f08c47fec0942fa0';
+
+const requiredFiles = [
+  'public/ads.txt',
+  'src/app/password-safety-checklist/page.tsx',
+  'src/app/about/page.tsx',
+  'src/app/contact/page.tsx',
+  'src/app/privacy/page.tsx',
+  'src/app/editorial-policy/page.tsx',
+];
+
+const requiredRoutes = [
+  '/',
+  '/ads.txt',
+  '/sitemap.xml',
+  '/password-safety-checklist',
+  '/about',
+  '/contact',
+  '/privacy',
+  '/editorial-policy',
+];
+
+async function assertFile(path) {
+  await access(path);
+  console.log(`ok file ${path}`);
+}
+
+async function fetchText(path) {
+  const url = `${BASE_URL}${path}`;
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok) {
+    throw new Error(`${url} returned HTTP ${response.status}`);
+  }
+  const text = await response.text();
+  console.log(`ok url ${url}`);
+  return text;
+}
+
+async function main() {
+  for (const path of requiredFiles) {
+    await assertFile(path);
+  }
+
+  const adsTxt = await readFile('public/ads.txt', 'utf8');
+  if (!adsTxt.includes(ADS_LINE)) {
+    throw new Error('public/ads.txt does not contain the expected AdSense publisher line');
+  }
+  console.log('ok local ads.txt publisher line');
+
+  for (const route of requiredRoutes) {
+    await fetchText(route);
+  }
+
+  const [homeSource, sitemap, liveAdsTxt] = await Promise.all([
+    readFile('src/app/page.tsx', 'utf8'),
+    fetchText('/sitemap.xml'),
+    fetchText('/ads.txt'),
+  ]);
+
+  if (!homeSource.includes('/password-safety-checklist')) {
+    throw new Error('Homepage source does not link to /password-safety-checklist');
+  }
+  if (!sitemap.includes('/password-safety-checklist')) {
+    throw new Error('Sitemap does not include /password-safety-checklist');
+  }
+  if (!liveAdsTxt.includes(ADS_LINE)) {
+    throw new Error('Live ads.txt does not contain the expected AdSense publisher line');
+  }
+
+  console.log(`AdSense readiness smoke check passed for ${BASE_URL}`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a repo-tracked AdSense readiness checklist.
- Adds a production smoke check for ads.txt, sitemap, trust pages, and /password-safety-checklist.
- Adds npm run check:adsense as the repeatable command.

## Verification
- npm run check:adsense

Closes #333
