### PR TITLE
infra: add issues:write permission to auto-merge.yml

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   policy-gate:


### PR DESCRIPTION
## What

Adds `issues: write` to the `permissions:` block in `auto-merge.yml`.

## Why

`gh pr merge --auto --squash` runs under `secrets.GITHUB_TOKEN`, which only had `contents: write` + `pull-requests: write` in this workflow. GitHub's "Closes #N" auto-close-on-merge behavior requires `issues: write` on the token performing the merge. Without it, PRs merge fine but their linked issues never auto-close — confirmed on this repo family where merged, verified-complete PRs stayed open indefinitely, making open/closed status an unreliable backlog signal.

## Scope

Touches only `.github/workflows/auto-merge.yml` (trusted infra path per `check_scope.py`'s owner fast path) — no linked issue needed.

## Verification

After merge, will confirm on the next real `Closes #N` PR that the linked issue actually flips to closed automatically.

**Risk level:** LOW (permission grant only, no logic change; token already trusted to merge PRs, this only lets it also close the issue that PR says it closes)
