### PR TITLE
infra: fix check_scope.py fail-open bug on unparseable Allowed paths

### DIFF
--- a/.github/scripts/check_scope.py
+++ b/.github/scripts/check_scope.py
@@ -36,8 +36,16 @@ def parse_paths(body, field):
     match = re.search(rf"\*\*{re.escape(field)}:\*\*\s*(.*?)(?=\n\*\*|\Z)", body or "", re.S | re.I)
     if not match:
         return []
+    section = match.group(1)
+    # Backward-compat: some older issues list paths inside a fenced code
+    # block (bare lines, no leading "-") instead of a bullet list. Try that
+    # first; fall back to bullet parsing if there's no fence.
+    fence = re.search(r"```[a-zA-Z]*\n(.*?)```", section, re.S)
+    if fence:
+        paths = [line.strip().strip("`") for line in fence.group(1).splitlines()]
+        return [p for p in paths if p]
     paths = []
-    for line in match.group(1).splitlines():
+    for line in section.splitlines():
         line = line.strip()
         if line.startswith("-"):
             paths.append(line.lstrip("- ").strip().strip("`"))
@@ -97,6 +105,14 @@ def main():
     issue = json.loads(raw)
     is_infra_issue = (issue.get("title") or "").lower().startswith("agios infra:")
     allowed = parse_paths(issue.get("body") or "", "Allowed paths")
+    if not allowed:
+        # Fail closed: a linked issue with no parseable "Allowed paths" list
+        # means scope is genuinely undeterminable. Previously this silently
+        # allowed every changed path through (empty list treated as "no
+        # restriction" instead of "nothing is allowed") -- a fail-open
+        # governance bug. Force a formatting fix instead of merging blind.
+        print(f"FAIL: Issue #{issue_number} has no parseable 'Allowed paths' list -- scope undeterminable, fix the issue's formatting")
+        sys.exit(1)
     blocked = GITHUB_META_BLOCKED + parse_paths(issue.get("body") or "", "Blocked paths")
     violations = []
     for path in changed:


### PR DESCRIPTION
## What

Fixes a fail-open bug in `check_scope.py`'s `parse_paths()` / violation logic.

## Bug

`parse_paths()` only recognized bullet-list lines (`- path`) under `**Allowed paths:**`. Some earlier issues used a fenced code block instead (paths as bare lines inside a ``` block, no bullets). When the parser can't find bullet lines it returns `[]` — and the violation check (`elif allowed and not matches(path, allowed)`) treats an empty `allowed` list as "no restriction" rather than "nothing is allowed." A scope check meant to enforce an allowlist was silently no-opping whenever an issue's formatting didn't match exactly what the parser expected. This is a fail-open governance bug, not a cosmetic formatting quirk.

## Fix

1. `parse_paths()` now also parses the fenced-code-block format (bare lines inside a ``` block) for backward compatibility with older issues, falling back to bullet parsing when there's no fence.
2. When a PR is linked to an issue (`Closes #N` found) but `parse_paths()` still returns an empty "Allowed paths" list, the check now **fails** ("scope undeterminable, fix the issue's formatting") instead of silently passing every changed path through. The unlinked-PR path (no `Closes #N` at all) is unchanged — it already failed correctly.

## Scope

Touches only `.github/scripts/check_scope.py` (trusted infra path per this file's own owner fast path) — no linked issue needed.

## Verification

Unit-tested `parse_paths()` directly against: the fenced-code-block format (new — parses correctly now), the existing bullet format (regression check — unchanged), backtick-wrapped bullet paths (regression check — unchanged), and a body with no Allowed-paths field at all (returns `[]`, which now correctly triggers the fail-closed path in `main()` rather than passing everything). Will also open a throwaway old-format issue + out-of-scope PR after merge to confirm the fail-closed behavior end-to-end against the live workflow.

**Risk level:** LOW (parser gains a new accepted format; the only behavior change for already-working issues is none — bullet-format parsing is untouched. The only PRs newly affected are ones linked to issues whose Allowed-paths didn't parse at all, which is exactly the case that was previously unsafe.)
