### PR TITLE
infra: explicit issue-close in auto-merge.yml (issues:write alone verified insufficient)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,6 +4,8 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
@@ -14,7 +16,7 @@ jobs:
   policy-gate:
     name: Policy-gated auto-merge
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
@@ -67,3 +69,40 @@ jobs:
             --repo "$REPO" \
             --auto \
             --squash
+
+  close-linked-issue:
+    name: Close linked issue on merge
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Explicitly close the linked issue
+        run: |
+          # GitHub's implicit "Closes #N" auto-close-on-merge is unreliable for
+          # PRs merged via `gh pr merge --auto` under GITHUB_TOKEN, even with
+          # issues: write granted (confirmed empirically: a throwaway PR with
+          # "Closes #N" in its body merged cleanly via auto-merge but left the
+          # issue open, while the same merge performed by a full-scope PAT
+          # closed it instantly). Rather than depend on that platform behavior,
+          # close explicitly here, triggered by the PR actually merging,
+          # regardless of who/what performed the merge.
+          PR_BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body')
+          ISSUE=$(echo "$PR_BODY" | grep -ioE "closes?\s+#[0-9]+" | grep -oE "[0-9]+" | head -1)
+
+          if [ -z "$ISSUE" ]; then
+            echo "No 'Closes #N' in PR #$PR body — nothing to close"
+            exit 0
+          fi
+
+          STATE=$(gh issue view "$ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null)
+          if [ "$STATE" = "CLOSED" ]; then
+            echo "Issue #$ISSUE already closed — nothing to do"
+            exit 0
+          fi
+
+          echo "Explicitly closing issue #$ISSUE (linked PR #$PR merged)"
+          gh issue close "$ISSUE" --repo "$REPO" \
+            --comment "Closed automatically: linked PR #$PR merged (https://github.com/$REPO/pull/$PR)."


### PR DESCRIPTION
## What

Adds an explicit issue-closing job to `auto-merge.yml`, triggered on `pull_request: types: [closed]` when `merged == true`.

## Why (follow-up to the issues:write fix)

After merging the `issues: write` permission fix, I ran a live end-to-end test: a throwaway PR with `Closes #N` in its body, merged through this exact workflow's `gh pr merge --auto --squash`. The PR merged cleanly (confirmed `merged_by: github-actions[bot]`), and GitHub's GraphQL `closingIssuesReferences` correctly showed the linked issue — but the issue **stayed open**. As an isolation check, I then merged an equivalent throwaway PR directly with a full-scope PAT instead of going through auto-merge, and that one closed its linked issue immediately. Same repo, same squash method, same "Closes #N" pattern — the only difference was the merging path. This matches a known, longstanding GitHub platform quirk (see cli/cli#6379) where `issues: write` is "sometimes required" for `gh pr merge --auto` to close linked issues, but not reliably sufficient on its own.

So the permission grant was necessary but not sufficient. Rather than depend further on GitHub's implicit closing-keyword behavior under auto-merge, this adds an explicit, idempotent close: on any PR close event where `merged == true`, parse `Closes #N` from the PR body and call `gh issue close` directly if the issue isn't already closed. This works regardless of merge path (auto-merge, direct API/PAT merge, or a human merging via the UI).

## Scope

Touches only `.github/workflows/auto-merge.yml` (trusted infra path) — no linked issue needed.

## Verification

Will re-run the same throwaway issue+PR test used to find the gap and confirm the issue now closes within seconds of merge via this workflow.

**Risk level:** LOW (additive job; existing `policy-gate` job's trigger/logic is unchanged, this only adds a second job scoped to a different event)
