### PR TITLE
infra: fix invalid gh --json field in auto-merge.yml poll loop

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -81,18 +81,18 @@ jobs:
           # is workflow_run, not GITHUB_TOKEN-caused, so it isn't subject to
           # that suppression) and close the issue explicitly once it does.
           echo "Waiting for PR #$PR to merge..."
-          MERGED="false"
+          PR_STATE="OPEN"
           for i in $(seq 1 24); do
-            MERGED=$(gh pr view "$PR" --repo "$REPO" --json merged --jq '.merged')
-            if [ "$MERGED" = "true" ]; then
+            PR_STATE=$(gh pr view "$PR" --repo "$REPO" --json state --jq '.state')
+            if [ "$PR_STATE" = "MERGED" ]; then
               echo "PR #$PR merged."
               break
             fi
             sleep 5
           done
 
-          if [ "$MERGED" != "true" ]; then
-            echo "PR #$PR has not merged after ~2 minutes of polling — leaving issue #$ISSUE open for now (backlog hygiene sweep will catch it if it merges later)"
+          if [ "$PR_STATE" != "MERGED" ]; then
+            echo "PR #$PR has not merged after ~2 minutes of polling (state: $PR_STATE) — leaving issue #$ISSUE open for now (backlog hygiene sweep will catch it if it merges later)"
             exit 0
           fi
 


### PR DESCRIPTION
## What

Fixes a bug in the previous PR's poll loop: `gh pr view --json merged` is not a valid field (confirmed via the actual failed run's error output, which lists all valid fields — `merged` isn't among them; `state` is, with value `"MERGED"` once merged). The job failed outright on its first loop iteration because of `set -e`, before ever reaching the close step.

## Evidence

Re-tested after the previous ("inline poll-and-close") PR merged: a fresh throwaway issue+PR pair merged fine via auto-merge (confirmed via REST API), but the `policy-gate` run for it shows `conclusion: failure`, with the log showing `gh: unknown JSON field: "merged"` (dumps the full list of valid fields, none of which is `merged`). Switched to `--json state --jq '.state'`, comparing against `"MERGED"`.

## Scope

Touches only `.github/workflows/auto-merge.yml` (trusted infra path) — no linked issue needed.

## Verification

Re-running the same throwaway test a fourth time; will confirm both a green `policy-gate` run and the issue actually closing this time.

**Risk level:** LOW (one field-name fix in an already-scoped poll loop; no logic change beyond that)
