### PR TITLE
[AGIOS] seo: update robots.txt to include sitemap URL

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://strongpasswordgenerator.dev/sitemap.xml
+Sitemap: /sitemap.xml


### PR DESCRIPTION
Closes #344

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `2.01` seconds
- Files changed: public/robots.txt

## Verification
````shell
cat public/robots.txt
````

Output:
```
User-agent: *
Allow: /

Sitemap: /sitemap.xml
```

## Issue body snapshot
- Allowed paths: public/robots.txt
- Blocked paths: .github/, .agios/, .env
- Risk level: LOW
- Auto-merge allowed: True