### PR TITLE
seo/bugfix: add canonical override to /blog index page

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -4,6 +4,9 @@ import { getSortedPosts, topicHubs } from '../../lib/posts';
 export const metadata = {
   title: 'Password Security Blog | Strong Password Generator',
   description: 'Explore articles on password security, password managers, phishing, and online privacy from Strong Password Generator.',
+  alternates: {
+    canonical: "/blog",
+  },
 };
 
 interface PostMeta {


### PR DESCRIPTION
Closes #336

Adds `alternates: { canonical: "/blog" }` to the blog index page's metadata so it self-references instead of inheriting the root layout's homepage canonical. No-op for individual blog post pages (already fixed).

**Allowed paths touched (matches issue #336):**
- src/app/blog/page.tsx

**Verification run locally:**
```
$ grep -A2 alternates src/app/blog/page.tsx
  alternates: {
    canonical: "/blog",
  },
$ npm run build   # succeeded
$ grep canonical .next/server/app/blog.html
<link rel="canonical" href="https://strongpasswordgenerator.dev/blog"/>
```

This issue was escalated to the Codex GitHub App ~13.7 hours ago with a 12-hour Claude fallback; no PR had been opened by Codex, so implementing directly per the escalation comment.