### PR TITLE
[AGIOS] ux: add custom branded 404 page (not-found.tsx)

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex flex-col items-center justify-center min-h-screen bg-white dark:bg-slate-900 text-center p-4">
+      <h1 className="text-9xl font-bold text-gray-800 dark:text-gray-200">404</h1>
+      <h2 className="mt-4 text-3xl font-semibold text-gray-700 dark:text-gray-300">Page Not Found</h2>
+      <p className="mt-2 text-lg text-gray-600 dark:text-gray-400">
+        The page you are looking for does not exist.
+      </p>
+      <div className="mt-6 flex flex-col gap-4 sm:flex-row">
+        <Link
+          href="/"
+          className="px-6 py-3 bg-white text-gray-800 rounded shadow hover:bg-gray-100 dark:bg-slate-800 dark:text-gray-100 dark:hover:bg-slate-700"
+        >
+          Back to Password Generator
+        </Link>
+        <Link
+          href="/blog"
+          className="px-6 py-3 bg-white text-gray-800 rounded shadow hover:bg-gray-100 dark:bg-slate-800 dark:text-gray-100 dark:hover:bg-slate-700"
+        >
+          Browse the blog
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #361

## Summary
AGIOS builder router completed implementation with `cerebras`.

## Builder
- Status: `success`
- Duration: `0.61` seconds
- Files changed: src/app/not-found.tsx

## Verification
````bash
npm run build && npm run lint
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 3.1s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/87) ...
  Generating static pages using 3 workers (21/87) 
  Generating static pages using 3 workers (43/87) 
  Generating static pages using 3 workers (65/87) 
✓ Generating static pages using 3 workers (87/87) in 1062.8ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /password-safety-checklist
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)


> strongpasswordgenerator@0.1.0 lint
> eslint


/home/runner/work/strongpasswordgenerator.dev/strongpasswordgenerator.dev/target/src/app/components/PassphraseGenerator.tsx
  39:9  warning  The 'copy' function makes the dependencies of useEffect Hook (at line 58) change on every render. To fix this, wrap the definition of 'copy' in its own useCallback() Hook  react-hooks/exhaustive-deps

✖ 1 problem (0 errors, 1 warning)
```

## Issue body snapshot
- Allowed paths: src/app/not-found.tsx
- Blocked paths: .github/**, .agios/**, *.env*
- Risk level: LOW
- Auto-merge allowed: True