### PR TITLE
[AGIOS] seo: add Open Graph meta tags to /privacy page

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Head from 'next/head';
 
 export const metadata = {
   title: 'Privacy Policy | Strong Password Generator',
@@ -46,6 +47,12 @@ export const metadata = {
 export default function PrivacyPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
+      <Head>
+        <meta property="og:title" content="Privacy Policy | Strong Password Generator" />
+        <meta property="og:description" content="Privacy policy for StrongPasswordGenerator.dev — we collect minimal data and never see your generated passwords." />
+        <meta property="og:url" content="https://strongpasswordgenerator.dev/privacy" />
+        <meta property="og:type" content="website" />
+      </Head>
       <header className="bg-white/80 backdrop-blur-md border-b border-slate-200/50 py-4 px-6 sticky top-0 z-10">
         <div className="max-w-3xl mx-auto flex justify-between items-center">
           <Link href="/" className="flex items-center gap-3">


### PR DESCRIPTION
Closes #366

## Summary
AGIOS builder router completed implementation with `cerebras`.

## Builder
- Status: `success`
- Duration: `0.8` seconds
- Files changed: src/app/privacy/page.tsx

## Verification
````shell
npm run build
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 3.0s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/87) ...
  Generating static pages using 3 workers (21/87) 
  Generating static pages using 3 workers (43/87) 
  Generating static pages using 3 workers (65/87) 
✓ Generating static pages using 3 workers (87/87) in 1134.4ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /password-safety-checklist
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/app/privacy/page.tsx
- Blocked paths: .github/, .agios/, .env
- Risk level: LOW
- Auto-merge allowed: True