### PR TITLE
[AGIOS] bugfix: getPostDescription ignores metaDescription field, silently falls back to excerpt

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -8,6 +8,7 @@ export interface PostMeta {
   readingTime: string;
   tags: string[];
   description?: string;
+  metaDescription?: string;
   excerpt: string;
 }
 
@@ -127,6 +128,7 @@ export function getPostsByCategory(categories: string[]) {
 
 export function getPostDescription(post: PostMeta) {
   if (post.description) return post.description;
+  if (post.metaDescription) return post.metaDescription;
   const cleaned = post.excerpt.replace(/\s+/g, " ").trim();
   if (cleaned.length <= 155) return cleaned;
   return `${cleaned.slice(0, 152).replace(/\s+\S*$/, "")}...`;


### PR DESCRIPTION
Closes #382

## Summary
AGIOS builder router completed implementation with `mistral`.

## Builder
- Status: `success`
- Duration: `2.52` seconds
- Files changed: src/lib/posts.ts

## Verification
````bash
npm run build && npx tsc --noEmit
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.9s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/87) ...
  Generating static pages using 3 workers (21/87) 
  Generating static pages using 3 workers (43/87) 
  Generating static pages using 3 workers (65/87) 
✓ Generating static pages using 3 workers (87/87) in 1001.5ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /password-safety-checklist
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/lib/posts.ts
- Blocked paths: .github/**, .agios/**, *.env*, src/posts/**, src/app/**
- Risk level: LOW
- Auto-merge allowed: True