### PR TITLE
[AGIOS] seo: add json-ld faqpage schema to privacy policy page

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -4,37 +4,7 @@ import Head from 'next/head';
 export const metadata = {
   title: 'Privacy Policy | Strong Password Generator',
   description: 'Privacy policy for StrongPasswordGenerator.dev — we collect minimal data and never see your generated passwords.',
-  openGraph: {  jsonLd: {
-    '@context': 'https://schema.org',
-    '@type': 'FAQPage',
-    mainEntity: [
-      {
-        '@type': 'Question',
-        name: 'Do you see the passwords I generate?',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: 'No, we never see the passwords you generate. Password generation happens entirely in your browser, using your browser\'s crypto.getRandomValues() API. Generated passwords are never transmitted to our servers, never logged, and never stored anywhere except optionally in your own browser\'s localStorage.',
-        },
-      },
-      {
-        '@type': 'Question',
-        name: 'What information do you collect?',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: 'We collect minimal, non-identifying data such as page views, referring URLs, general geographic region (country-level), browser type, device type, and affiliate/outbound link click events, reviewed in aggregate. We do not collect names, email addresses, or any personally identifiable information unless you choose to contact us directly.',
-        },
-      },
-      {
-        '@type': 'Question',
-        name: 'How do you use cookies and local storage?',
-        acceptedAnswer: {
-          '@type': 'Answer',
-          text: 'We use browser localStorage to save your password generator preferences (length, character options) and password history between sessions. This data stays on your device and is never sent to us. We may also use cookies for analytics purposes, which you can disable in your browser settings.',
-        },
-      },
-    ],
-  },
-
+  openGraph: {
     title: 'Privacy Policy | Strong Password Generator',
     description: 'Privacy policy for StrongPasswordGenerator.dev — we collect minimal data and never see your generated passwords.',
     url: 'https://strongpasswordgenerator.dev/privacy',
@@ -65,12 +35,42 @@ export default function PrivacyPage() {
           </Link>
           <Link href="/" className="text-sm text-indigo-600 hover:text-indigo-800 font-medium">← Generator</Link>
         </div>
-      </header>      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: `{
-  "@context": "https://schema.org",
-  "@type": "WebPage",
-  "name": "Privacy Policy",
-  "url": "https://strongpasswordgenerator.dev/privacy"
-}` }} />
+      </header>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'Do you see the passwords I generate?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'No, we never see the passwords you generate. Password generation happens entirely in your browser, using your browser\'s crypto.getRandomValues() API. Generated passwords are never transmitted to our servers, never logged, and never stored anywhere except optionally in your own browser\'s localStorage.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'What information do you collect?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'We collect minimal, non-identifying data such as page views, referring URLs, general geographic region (country-level), browser type, device type, and affiliate/outbound link click events, reviewed in aggregate. We do not collect names, email addresses, or any personally identifiable information unless you choose to contact us directly.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'How do you use cookies and local storage?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'We use browser localStorage to save your password generator preferences (length, character options) and password history between sessions. This data stays on your device and is never sent to us. We may also use cookies for analytics purposes, which you can disable in your browser settings.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
 
       <main className="max-w-3xl mx-auto p-6">
         <div className="bg-white rounded-3xl shadow-xl shadow-slate-200/50 p-8 border border-slate-100">


### PR DESCRIPTION
Closes #393

## Summary
AGIOS builder router completed implementation with `nvidia-qwen35-122b`.

## Builder
- Status: `success`
- Duration: `119.86` seconds
- Files changed: src/app/privacy/page.tsx

## Verification
````shell
npm run build
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.9s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/87) ...
  Generating static pages using 3 workers (21/87) 
  Generating static pages using 3 workers (43/87) 
  Generating static pages using 3 workers (65/87) 
✓ Generating static pages using 3 workers (87/87) in 1185.6ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/best-password-manager-for-families-2026
│ ├ /blog/public-wifi-security-tips
│ ├ /blog/nordpass-review-2026
│ └ [+69 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /password-safety-checklist
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/app/privacy/page.tsx
- Blocked paths: .github/, .agios/, .env
- Risk level: LOW
- Auto-merge allowed: True