### PR TITLE
[AGIOS] seo: add BreadcrumbList json-ld schema to blog topic hub pages (password-managers, password-security, phishing)

### DIFF
--- a/src/app/blog/password-managers/page.tsx
+++ b/src/app/blog/password-managers/page.tsx
@@ -25,10 +25,21 @@ export const metadata: Metadata = {
   },
 };
 
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://strongpasswordgenerator.dev/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://strongpasswordgenerator.dev/blog" },
+    { "@type": "ListItem", "position": 3, "name": "Password Managers", "item": "https://strongpasswordgenerator.dev/blog/password-managers" }
+  ]
+};
+
 export default function PasswordManagersHub() {
   return (
     <>
-      <Script id="collection-schema" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({"@context":"https://schema.org","@type":"CollectionPage","name":"Password Managers","description":"Learn about the best password managers, how they work, and why you should use one to secure your online accounts.","url":"https://strongpasswordgenerator.dev/blog/password-managers"}) }} />      <NordPassCTA />
+      <Script id="collection-schema" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({"@context":"https://schema.org","@type":"CollectionPage","name":"Password Managers","description":"Learn about the best password managers, how they work, and why you should use one to secure your online accounts.","url":"https://strongpasswordgenerator.dev/blog/password-managers"}) }} />
+      <Script id="breadcrumb-schema" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />      <NordPassCTA />
       <TopicHubPage hub={hub} />
     </>
   );

--- a/src/app/blog/password-security/page.tsx
+++ b/src/app/blog/password-security/page.tsx
@@ -24,10 +24,21 @@ export const metadata: Metadata = {
   },
 };
 
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://strongpasswordgenerator.dev/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://strongpasswordgenerator.dev/blog" },
+    { "@type": "ListItem", "position": 3, "name": "Password Security", "item": "https://strongpasswordgenerator.dev/blog/password-security" }
+  ]
+};
+
 export default function PasswordSecurityHub() {
   return (
     <>
       <Script id="collection-schema" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({"@context":"https://schema.org","@type":"CollectionPage","name": `${hub.title} | Strong Password Generator`,"description":"Discover essential tips and strategies for creating strong passwords, protecting your accounts, and improving your overall password security.","url":"https://strongpasswordgenerator.dev/blog/password-security"}) }} />
+      <Script id="breadcrumb-schema" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
       <TopicHubPage hub={hub} />
     </>
   );

--- a/src/app/blog/phishing/page.tsx
+++ b/src/app/blog/phishing/page.tsx
@@ -19,6 +19,16 @@ export const metadata: Metadata = {
   },
 };
 
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://strongpasswordgenerator.dev/" },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://strongpasswordgenerator.dev/blog" },
+    { "@type": "ListItem", "position": 3, "name": "Phishing", "item": "https://strongpasswordgenerator.dev/blog/phishing" }
+  ]
+};
+
 export default function PhishingHub() {
   const collectionSchema = {
     "@context": "https://schema.org",
@@ -35,6 +45,7 @@ export default function PhishingHub() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionSchema) }}
       />
+      <Script id="breadcrumb-schema" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
       <TopicHubPage hub={hub} />
     </>
   );


### PR DESCRIPTION
Closes #412

## Summary
AGIOS builder router completed implementation with `mistral`.

## Builder
- Status: `success`
- Duration: `8.6` seconds
- Files changed: src/app/blog/password-managers/page.tsx, src/app/blog/password-security/page.tsx, src/app/blog/phishing/page.tsx

## Verification
````shell
npm run build
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.9s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/91) ...
  Generating static pages using 3 workers (22/91) 
  Generating static pages using 3 workers (45/91) 
  Generating static pages using 3 workers (68/91) 
✓ Generating static pages using 3 workers (91/91) in 1197.7ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/ai-voice-cloning-scams
│ ├ /blog/password-manager-for-college-students
│ ├ /blog/data-broker-opt-out-guide
│ └ [+73 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /password-safety-checklist
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/app/blog/password-managers/page.tsx, src/app/blog/password-security/page.tsx, src/app/blog/phishing/page.tsx
- Blocked paths: .github/**, .agios/**, *.env*
- Risk level: LOW
- Auto-merge allowed: True