### PR TITLE
[AGIOS] bugfix: remove dead legacy next/head Head usage in TopicHubPage.tsx

### DIFF
--- a/src/app/blog/TopicHubPage.tsx
+++ b/src/app/blog/TopicHubPage.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { getHubPosts, getPostsByCategory, type TopicHub } from '../../lib/posts';
-import RelatedPostsList from '../components/RelatedPostsList';import Head from 'next/head';
+import RelatedPostsList from '../components/RelatedPostsList';
 
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://strongpasswordgenerator.dev';
@@ -13,17 +13,7 @@ export default function TopicHubPage({ hub }: { hub: TopicHub }) {
     .slice(0, 5); // Limit to 5 related posts
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">      <Head>
-        <meta property="og:title" content={hub.title} />
-        <meta property="og:description" content={hub.description} />
-        <meta property="og:image" content={`${SITE_URL}/og-image.svg`} />
-        <meta property="og:url" content={`${SITE_URL}/blog/${hub.slug}`} />
-        <meta property="og:type" content="website" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={hub.title} />
-        <meta name="twitter:description" content={hub.description} />
-        <meta name="twitter:image" content={`${SITE_URL}/og-image.svg`} />
-      </Head>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
 
       <script
         type="application/ld+json"


### PR DESCRIPTION
Closes #420

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `10.77` seconds
- Files changed: src/app/blog/TopicHubPage.tsx

## Verification
````bash
npm run build && npm run lint && ! grep -q "next/head" src/app/blog/TopicHubPage.tsx
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 2.1s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/91) ...
  Generating static pages using 3 workers (22/91) 
  Generating static pages using 3 workers (45/91) 
  Generating static pages using 3 workers (68/91) 
✓ Generating static pages using 3 workers (91/91) in 939.6ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/ai-voice-cloning-scams
│ ├ /blog/password-manager-for-college-students
│ ├ /blog/data-broker-opt-out-guide
│ └ [+73 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /password-safety-checklist
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)


> strongpasswordgenerator@0.1.0 lint
> eslint


/home/runner/work/strongpasswordgenerator.dev/strongpasswordgenerator.dev/target/src/app/components/PassphraseGenerator.tsx
  39:9  warning  The 'copy' function makes the dependencies of useEffect Hook (at line 58) change on every render. To fix this, wrap the definition of 'copy' in its own useCallback() Hook  react-hooks/exhaustive-deps

✖ 1 problem (0 errors, 1 warning)
```

## Issue body snapshot
- Allowed paths: src/app/blog/TopicHubPage.tsx
- Blocked paths: .github/**, .agios/**, *.env*
- Risk level: LOW
- Auto-merge allowed: True