### PR TITLE
[AGIOS] seo: add canonical URL and Twitter Card metadata to privacy page

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -11,6 +11,14 @@ export const metadata = {
     type: 'website',
     images: [{ url: '/og-image.svg' }],
   },
+  alternates: {
+    canonical: 'https://strongpasswordgenerator.dev/privacy',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Privacy Policy | Strong Password Generator',
+    description: 'Privacy policy for StrongPasswordGenerator.dev — we collect minimal data and never see your generated passwords.',
+  },
 };
 
 export default function PrivacyPage() {


### PR DESCRIPTION
Closes #424

## Summary
AGIOS builder router completed implementation with `cerebras`.

## Builder
- Status: `success`
- Duration: `0.65` seconds
- Files changed: src/app/privacy/page.tsx

## Verification
````bash
npm run build && npm run lint
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 4.2s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/91) ...
  Generating static pages using 3 workers (22/91) 
  Generating static pages using 3 workers (45/91) 
  Generating static pages using 3 workers (68/91) 
✓ Generating static pages using 3 workers (91/91) in 1298.7ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/ai-voice-cloning-scams
│ ├ /blog/password-manager-for-college-students
│ ├ /blog/data-broker-opt-out-guide
│ └ [+73 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /password-safety-checklist
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)


> strongpasswordgenerator@0.1.0 lint
> eslint


/home/runner/work/strongpasswordgenerator.dev/strongpasswordgenerator.dev/target/src/app/components/PassphraseGenerator.tsx
  39:9  warning  The 'copy' function makes the dependencies of useEffect Hook (at line 58) change on every render. To fix this, wrap the definition of 'copy' in its own useCallback() Hook  react-hooks/exhaustive-deps

✖ 1 problem (0 errors, 1 warning)
```

## Issue body snapshot
- Allowed paths: src/app/privacy/page.tsx
- Blocked paths: .github/**, .agios/**, *.env*
- Risk level: LOW
- Auto-merge allowed: True