### PR TITLE
[AGIOS] seo: add Twitter Card metadata to editorial-policy page

### DIFF
--- a/src/app/editorial-policy/page.tsx
+++ b/src/app/editorial-policy/page.tsx
@@ -16,6 +16,12 @@ export const metadata: Metadata = {
     type: 'website',
     images: [{ url: '/og-image.svg' }],
   },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Editorial Policy | Strong Password Generator',
+    description: 'How StrongPasswordGenerator.dev researches, reviews, and monetizes password security guides and tool recommendations.',
+    images: ['/og-image.svg'],
+  },
 };
 
 export default function EditorialPolicyPage() {


### PR DESCRIPTION
Closes #428

## Summary
AGIOS builder router completed implementation with `gemini-flash`.

## Builder
- Status: `success`
- Duration: `2.59` seconds
- Files changed: src/app/editorial-policy/page.tsx

## Verification
````shell
npm run build
````

Output:
```
> strongpasswordgenerator@0.1.0 build
> next build

⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 3.3s
  Running TypeScript ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/93) ...
  Generating static pages using 3 workers (23/93) 
  Generating static pages using 3 workers (46/93) 
  Generating static pages using 3 workers (69/93) 
✓ Generating static pages using 3 workers (93/93) in 1383.5ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/ai-voice-cloning-scams
│ ├ /blog/password-manager-for-college-students
│ ├ /blog/data-broker-opt-out-guide
│ └ [+75 more paths]
├ ○ /blog/password-managers
├ ○ /blog/password-security
├ ○ /blog/phishing
├ ○ /contact
├ ○ /editorial-policy
├ ○ /password-safety-checklist
├ ○ /privacy
├ ○ /recommended-tools
└ ○ /sitemap.xml


○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
```

## Issue body snapshot
- Allowed paths: src/app/editorial-policy/page.tsx
- Blocked paths: .github/**, .agios/**, *.env*
- Risk level: LOW
- Auto-merge allowed: True