### PR TITLE
Improve SPG AdSense and revenue readiness

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -203,6 +203,7 @@ export default function AboutPage() {
           <Link href="/recommended-tools" className="hover:text-indigo-600">Tools</Link>
           <Link href="/privacy" className="hover:text-indigo-600">Privacy</Link>
           <Link href="/editorial-policy" className="hover:text-indigo-600">Editorial Policy</Link>
+          <Link href="/terms" className="hover:text-indigo-600">Terms</Link>
         </div>
         <p>© 2026 StrongPasswordGenerator.dev</p>
       </footer>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -42,10 +42,41 @@ const nordPassRecommendedSlugs = new Set([
   'free-vs-paid-password-managers-2026',
   'password-manager-vs-browser-autofill',
   'how-to-create-strong-password',
+  'best-password-manager-iphone-ios-2026',
+  'password-manager-for-business',
+  'best-password-manager-for-business-2026',
+]);
+
+const nordProtectRecommendedSlugs = new Set([
+  'best-identity-theft-protection-2026',
+  'identity-theft-protection-guide',
+  'dark-web-monitoring-explained',
+  'data-breach-what-to-do',
+  'how-to-check-if-youve-been-hacked',
+  'how-to-recover-from-identity-theft',
+  'how-to-freeze-your-credit',
+]);
+
+const nordVpnRecommendedSlugs = new Set([
+  'nordvpn-review-2026',
+  'nordvpn-vs-expressvpn',
+  'how-to-use-a-vpn-for-privacy',
+  'vpn-worth-it-2026',
+  'vpn-for-remote-work',
+  'public-wifi-security-tips',
+  'password-security-for-remote-workers',
 ]);
 
 function getAffiliateProduct(post: PostData): 'bitwarden' | 'nordpass' | 'nordvpn' | 'nordprotect' {
   const topicText = `${post.slug} ${post.category} ${post.tags.join(' ')} ${post.title}`.toLowerCase();
+
+  if (nordVpnRecommendedSlugs.has(post.slug)) {
+    return 'nordvpn';
+  }
+
+  if (nordProtectRecommendedSlugs.has(post.slug)) {
+    return 'nordprotect';
+  }
 
   if (topicText.includes('vpn') || topicText.includes('wifi') || topicText.includes('remote work')) {
     return 'nordvpn';
@@ -61,11 +92,17 @@ function getAffiliateProduct(post: PostData): 'bitwarden' | 'nordpass' | 'nordvp
     return 'nordprotect';
   }
 
-  if (topicText.includes('nordpass') || topicText.includes('password manager') || topicText.includes('password')) {
+  if (
+    topicText.includes('nordpass') ||
+    topicText.includes('password manager') ||
+    topicText.includes('browser autofill') ||
+    topicText.includes('lastpass') ||
+    topicText.includes('dashlane')
+  ) {
     return 'nordpass';
   }
 
-  return 'bitwarden';
+  return 'nordpass';
 }
 
 export async function generateStaticParams() {
@@ -252,7 +289,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                       <a
                         href={card.href}
                         target="_blank"
-                        rel="noopener noreferrer sponsored"
+                        rel={card.monetized ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
                         className="mt-4 inline-block text-sm font-semibold text-amber-700 hover:underline"
                       >
                         {card.cta} →
@@ -279,7 +316,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
               <strong>Recommended:</strong> We use and recommend{' '}<a
                 href="https://bitwarden.com/?utm_source=strongpasswordgenerator"
                 target="_blank"
-                rel="noopener noreferrer sponsored"
+                rel="noopener noreferrer"
                 className="font-semibold underline hover:text-indigo-700"
               >
                 Bitwarden
@@ -366,6 +403,13 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
       </main>
 
       <footer className="text-center py-6 text-slate-500 text-sm mt-8">
+        <div className="mb-2 flex justify-center gap-5 flex-wrap text-xs text-slate-400">
+          <Link href="/about" className="hover:text-indigo-600">About</Link>
+          <Link href="/privacy" className="hover:text-indigo-600">Privacy</Link>
+          <Link href="/terms" className="hover:text-indigo-600">Terms</Link>
+          <Link href="/editorial-policy" className="hover:text-indigo-600">Editorial Policy</Link>
+          <Link href="/contact" className="hover:text-indigo-600">Contact</Link>
+        </div>
         <p>🔒 All passwords are generated locally. Nothing is sent to any server.</p>
       </footer>
     </div>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -155,6 +155,13 @@ export default function BlogPage() {
       </main>
 
       <footer className="text-center py-6 text-slate-500 text-sm mt-8">
+        <div className="mb-2 flex justify-center gap-5 flex-wrap text-xs text-slate-400">
+          <Link href="/about" className="hover:text-indigo-600">About</Link>
+          <Link href="/privacy" className="hover:text-indigo-600">Privacy</Link>
+          <Link href="/terms" className="hover:text-indigo-600">Terms</Link>
+          <Link href="/editorial-policy" className="hover:text-indigo-600">Editorial Policy</Link>
+          <Link href="/contact" className="hover:text-indigo-600">Contact</Link>
+        </div>
         <p>🔒 <Link href="/" className="text-indigo-600 hover:underline">Generate a secure password</Link> — All passwords are created locally. Nothing is sent to any server.</p>
       </footer>
     </div>

--- a/src/app/blog/password-managers/page.tsx
+++ b/src/app/blog/password-managers/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
 import TopicHubPage from '../TopicHubPage';
 import { topicHubs } from '../../../lib/posts';
-import NordPassCTA from '../../components/NordPassCTA';import Script from 'next/script';
+import AffiliateCTA from '../../components/AffiliateCTA';
+import NordPassCTA from '../../components/NordPassCTA';
 
 const hub = topicHubs.find((item) => item.slug === 'password-managers')!;
 
@@ -27,9 +30,72 @@ export const metadata: Metadata = {
 
 export default function PasswordManagersHub() {
   return (
-    <>
-      <Script id="collection-schema" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({"@context":"https://schema.org","@type":"CollectionPage","name":"Password Managers","description":"Learn about the best password managers, how they work, and why you should use one to secure your online accounts.","url":"https://strongpasswordgenerator.dev/blog/password-managers"}) }} />      <NordPassCTA />
+    <div className="min-h-screen bg-white">
+      <Script
+        id="collection-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "CollectionPage",
+            name: "Password Managers",
+            description: "Learn about the best password managers, how they work, and why you should use one to secure your online accounts.",
+            url: "https://strongpasswordgenerator.dev/blog/password-managers",
+          }),
+        }}
+      />
       <TopicHubPage hub={hub} />
-    </>
+
+      <section className="mx-auto max-w-5xl px-6 pb-10">
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-indigo-600">Commercial shortlist</p>
+          <h2 className="mb-3 text-2xl font-bold text-slate-900">Start with the right password manager path</h2>
+          <p className="max-w-3xl text-sm leading-7 text-slate-600">
+            Most people do not need another generic roundup. They need the shortest path to the right decision:
+            best free option, best family setup, best business controls, or best open-source choice.
+          </p>
+
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="mb-1 text-sm font-semibold text-slate-900">Best first stop for most readers</p>
+              <p className="mb-3 text-sm leading-6 text-slate-600">Compare the main consumer options before you commit to a vault, browser extension, and migration flow.</p>
+              <Link href="/blog/nordpass-review-2026" className="text-sm font-semibold text-indigo-600 hover:underline">Read the NordPass review</Link>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="mb-1 text-sm font-semibold text-slate-900">Best for families</p>
+              <p className="mb-3 text-sm leading-6 text-slate-600">Shared vaults, recovery, and non-technical onboarding matter more than feature lists.</p>
+              <Link href="/blog/best-password-manager-for-families-2026" className="text-sm font-semibold text-indigo-600 hover:underline">Compare family plans</Link>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="mb-1 text-sm font-semibold text-slate-900">Best for teams</p>
+              <p className="mb-3 text-sm leading-6 text-slate-600">Admin controls, provisioning, and offboarding become the real buying criteria once a business is involved.</p>
+              <Link href="/blog/best-password-manager-for-business-2026" className="text-sm font-semibold text-indigo-600 hover:underline">See business picks</Link>
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-4 lg:grid-cols-[1.4fr,1fr]">
+            <div className="rounded-xl border border-slate-200 bg-white p-5">
+              <h3 className="mb-2 text-lg font-semibold text-slate-900">How to choose in five minutes</h3>
+              <ol className="space-y-2 text-sm leading-6 text-slate-600">
+                <li>1. Pick <strong className="text-slate-900">Bitwarden</strong> if open source, auditability, or self-hosting matter most.</li>
+                <li>2. Pick <strong className="text-slate-900">NordPass</strong> if you want the cleanest mainstream setup with a strong free on-ramp.</li>
+                <li>3. Pick <strong className="text-slate-900">1Password</strong> if family sharing or team workflow is the main job.</li>
+                <li>4. Add <strong className="text-slate-900">NordProtect</strong> if your concern has moved from password hygiene to active breach exposure.</li>
+              </ol>
+              <div className="mt-4 flex flex-wrap gap-3 text-sm">
+                <Link href="/recommended-tools" className="font-semibold text-indigo-600 hover:underline">Open the full tools page</Link>
+                <Link href="/blog/password-manager-vs-browser-autofill" className="font-semibold text-indigo-600 hover:underline">Browser autofill vs manager</Link>
+                <Link href="/blog/bitwarden-setup-guide" className="font-semibold text-indigo-600 hover:underline">Bitwarden setup guide</Link>
+              </div>
+            </div>
+            <AffiliateCTA product="nordpass" />
+          </div>
+
+          <div className="mt-6">
+            <NordPassCTA />
+          </div>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/src/app/components/AffiliateCTA.tsx
+++ b/src/app/components/AffiliateCTA.tsx
@@ -4,6 +4,8 @@ import { affiliates, type AffiliateProduct } from "../../lib/affiliates";
 
 export default function AffiliateCTA({ product }: { product: AffiliateProduct }) {
   const a = affiliates[product];
+  const rel = a.monetized ? "noopener noreferrer sponsored" : "noopener noreferrer";
+  const ariaLabel = a.monetized ? `${a.cta} — affiliate link` : `${a.cta} — external link`;
   return (
     <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-4 flex flex-col sm:flex-row sm:items-center gap-4">
       <div className="flex-1">
@@ -14,8 +16,8 @@ export default function AffiliateCTA({ product }: { product: AffiliateProduct })
         <a
           href={a.url}
           target="_blank"
-          rel="noopener noreferrer sponsored"
-          aria-label={`${a.cta} — affiliate link`}
+          rel={rel}
+          aria-label={ariaLabel}
           className="inline-block bg-indigo-600 text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-indigo-700 transition"
         >
           {a.cta} →

--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -36,15 +36,13 @@ export default function Analytics() {
 
             var isExternal = url.hostname && url.hostname !== window.location.hostname;
             var href = link.href;
-            var isAffiliate = /sponsored|affiliate/i.test(link.rel || '') || /awin1|kqzyfj|cj|nordpass|nordvpn|1password|bitwarden/i.test(href);
+            var isAffiliate = /sponsored|affiliate/i.test(link.rel || '') || /awin1|kqzyfj|cj/i.test(href);
             var partner = 'external';
 
-            if (/kqzyfj|nordpass/i.test(href)) partner = 'nordpass';
-            else if (/nordvpn/i.test(href)) partner = 'nordvpn';
-            else if (/nordprotect/i.test(href)) partner = 'nordprotect';
+            if (/kqzyfj/i.test(href)) partner = 'nordpass';
+            else if (/awin1.*15132/i.test(href)) partner = 'nordvpn';
+            else if (/awin1.*123620/i.test(href)) partner = 'nordprotect';
             else if (/awin1/i.test(href)) partner = 'awin';
-            else if (/1password/i.test(href)) partner = '1password';
-            else if (/bitwarden/i.test(href)) partner = 'bitwarden';
 
             if (isAffiliate || isExternal) {
               window.gtag('event', isAffiliate ? 'affiliate_click' : 'outbound_click', {

--- a/src/app/components/MoneyNextStep.tsx
+++ b/src/app/components/MoneyNextStep.tsx
@@ -4,6 +4,8 @@ const familyMatchers = ["family", "kids", "seniors", "iphone", "android"];
 const businessMatchers = ["business", "remote work", "teams", "github", "wordpress"];
 const identityMatchers = ["identity", "breach", "dark web", "credit", "hacked"];
 const vpnMatchers = ["vpn", "public wifi", "remote work", "privacy", "network"];
+const passwordManagerMatchers = ["password manager", "bitwarden", "nordpass", "1password", "dashlane", "lastpass", "browser autofill"];
+const setupMatchers = ["strong password", "password reuse", "passkeys", "authenticator", "2fa", "password audit"];
 
 export default function MoneyNextStep({ tags, category }: { tags: string[]; category: string }) {
   const topicText = `${category} ${tags.join(" ")}`.toLowerCase();
@@ -31,6 +33,18 @@ export default function MoneyNextStep({ tags, category }: { tags: string[]; cate
               label: "Review VPN protection",
               body: "A password manager protects accounts. A VPN protects traffic when you are on public or untrusted networks.",
             }
+          : passwordManagerMatchers.some((term) => topicText.includes(term))
+            ? {
+                href: "/blog/password-managers",
+                label: "Compare password manager options",
+                body: "If you are choosing between Bitwarden, NordPass, 1Password, or browser autofill, start with the comparison cluster instead of a generic tools page.",
+              }
+            : setupMatchers.some((term) => topicText.includes(term))
+              ? {
+                  href: "/blog/bitwarden-setup-guide",
+                  label: "Start with a free password manager",
+                  body: "The easiest next step after better password habits is putting those passwords into a manager you will actually keep using.",
+                }
           : {
               href: "/recommended-tools",
               label: "See recommended security tools",

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -103,6 +103,7 @@ export default function ContactPage() {
           <Link href="/recommended-tools" className="hover:text-indigo-600">Tools</Link>
           <Link href="/privacy" className="hover:text-indigo-600">Privacy</Link>
           <Link href="/editorial-policy" className="hover:text-indigo-600">Editorial Policy</Link>
+          <Link href="/terms" className="hover:text-indigo-600">Terms</Link>
         </div>
         <p>© 2026 StrongPasswordGenerator.dev</p>
       </footer>

--- a/src/app/editorial-policy/page.tsx
+++ b/src/app/editorial-policy/page.tsx
@@ -232,6 +232,18 @@ export default function EditorialPolicyPage() {
           </div>
         </article>
       </main>
+
+      <footer className="max-w-3xl mx-auto px-6 py-8 mt-8 border-t border-slate-200 text-center text-sm text-slate-400">
+        <div className="flex justify-center gap-6 mb-3 flex-wrap">
+          <Link href="/" className="hover:text-indigo-600">Home</Link>
+          <Link href="/blog" className="hover:text-indigo-600">Blog</Link>
+          <Link href="/recommended-tools" className="hover:text-indigo-600">Tools</Link>
+          <Link href="/about" className="hover:text-indigo-600">About</Link>
+          <Link href="/privacy" className="hover:text-indigo-600">Privacy</Link>
+          <Link href="/terms" className="hover:text-indigo-600">Terms</Link>
+        </div>
+        <p>© 2026 StrongPasswordGenerator.dev</p>
+      </footer>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -605,11 +605,24 @@ function PasswordGeneratorPage() {
         </div>
       )}
 
-      <section className="max-w-xl mx-auto px-4 py-8">
+      <section className="max-w-3xl mx-auto px-4 py-8">
         <h2 className="text-lg font-semibold text-slate-700 mb-4 text-center">Protect your passwords with a manager:</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <AffiliateCTA product="bitwarden" />
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[1.2fr_0.8fr]">
           <AffiliateCTA product="nordpass" />
+          <div className="rounded-xl border border-slate-200 bg-white p-4">
+            <span className="inline-block text-xs font-bold uppercase tracking-wide text-slate-500 mb-1">
+              Editorial pick
+            </span>
+            <p className="text-sm text-slate-700 mb-3">
+              Want a strong free option first? Read the Bitwarden setup guide and compare it against paid managers before you switch.
+            </p>
+            <Link
+              href="/blog/bitwarden-setup-guide"
+              className="inline-block text-sm font-semibold text-indigo-600 hover:text-indigo-700"
+            >
+              Read the Bitwarden guide →
+            </Link>
+          </div>
         </div>
       </section>
 
@@ -620,6 +633,7 @@ function PasswordGeneratorPage() {
           <a href="/recommended-tools" className="hover:text-indigo-600">Recommended Tools</a>
           <a href="/about" className="hover:text-indigo-600">About</a>
           <a href="/privacy" className="hover:text-indigo-600">Privacy Policy</a>
+          <a href="/terms" className="hover:text-indigo-600">Terms</a>
           <a href="/contact" className="hover:text-indigo-600">Contact</a>
         </div>
         <p>🔒 Passwords generated locally — never sent to any server.</p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -183,6 +183,7 @@ export default function PrivacyPage() {
           <Link href="/recommended-tools" className="hover:text-indigo-600">Tools</Link>
           <Link href="/about" className="hover:text-indigo-600">About</Link>
           <Link href="/contact" className="hover:text-indigo-600">Contact</Link>
+          <Link href="/terms" className="hover:text-indigo-600">Terms</Link>
         </div>
         <p>© 2026 StrongPasswordGenerator.dev</p>
       </footer>

--- a/src/app/recommended-tools/page.tsx
+++ b/src/app/recommended-tools/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import Script from 'next/script';
 import AffiliateCTA from '../components/AffiliateCTA';
-import NordPassCTA from '../components/NordPassCTA';import PasswordManagerComparisonTable from '../components/PasswordManagerComparisonTable';
+import NordPassCTA from '../components/NordPassCTA';
+import PasswordManagerComparisonTable from '../components/PasswordManagerComparisonTable';
 import { affiliates } from '../../lib/affiliates';
 
 export const metadata: Metadata = {
@@ -36,7 +37,7 @@ const tools = [
         url: affiliates.nordpass.url,
         badge: 'Best Free Option',
         badgeColor: '#10b981',
-        sponsored: true,
+        monetized: affiliates.nordpass.monetized,
         features: ['Zero-knowledge XChaCha20 encryption', 'Data breach scanner', 'Password health report', 'Free tier available', 'Secure password sharing'],
       },
       {
@@ -46,7 +47,7 @@ const tools = [
         url: affiliates.bitwarden.url,
         badge: 'Open Source',
         badgeColor: '#175DDC',
-        sponsored: true,
+        monetized: affiliates.bitwarden.monetized,
         features: ['End-to-end encrypted vault', 'Fully open-source & audited', 'Free tier with unlimited passwords', 'TOTP authenticator built-in', 'Self-hosting option available'],
       },
       {
@@ -56,7 +57,7 @@ const tools = [
         url: 'https://1password.com',
         badge: 'Best for Teams',
         badgeColor: '#3b82f6',
-        sponsored: true,
+        monetized: false,
         features: ['Watchtower breach monitoring', 'Travel Mode (hide vaults)', 'Passkey support', 'Family and team plans', 'Emergency access'],
       },
     ],
@@ -71,7 +72,7 @@ const tools = [
         url: affiliates.nordvpn.url,
         badge: 'Top Pick',
         badgeColor: '#6366f1',
-        sponsored: true,
+        monetized: affiliates.nordvpn.monetized,
         features: ['6,000+ servers in 60+ countries', 'Verified no-logs policy', 'Dark Web Monitor', 'NordLynx (WireGuard) protocol', 'Built-in threat protection'],
       },
     ],
@@ -86,7 +87,7 @@ const tools = [
         url: 'https://avast.com',
         badge: 'Free Tier Available',
         badgeColor: '#f59e0b',
-        sponsored: true,
+        monetized: false,
         features: ['Real-time malware protection', 'Ransomware shield', 'Wi-Fi inspector', 'Webcam protection (premium)', 'Free tier available'],
       },
       {
@@ -96,7 +97,7 @@ const tools = [
         url: 'https://mcafee.com',
         badge: 'All-in-One',
         badgeColor: '#ef4444',
-        sponsored: true,
+        monetized: false,
         features: ['Antivirus + VPN bundled', 'Identity monitoring', 'Password manager included', 'Multi-device support', 'Safe browsing extension'],
       },
     ],
@@ -111,7 +112,7 @@ const tools = [
         url: affiliates.nordprotect.url,
         badge: 'Top Pick',
         badgeColor: '#8b5cf6',
-        sponsored: true,
+        monetized: affiliates.nordprotect.monetized,
         features: ['Dark web monitoring', 'Real-time breach alerts', 'Identity theft insurance', 'Personal data scanning', 'Backed by Nord Security'],
       },
     ],
@@ -163,6 +164,30 @@ const paths = [
   },
 ];
 
+const firstMoveCards = [
+  {
+    title: 'Stop password reuse',
+    description: 'Best first purchase for most readers because reused passwords turn one leak into several account takeovers.',
+    href: affiliates.nordpass.url,
+    cta: 'Start with NordPass',
+    monetized: affiliates.nordpass.monetized,
+  },
+  {
+    title: 'Protect public Wi-Fi',
+    description: 'Best next layer if you travel, work remotely, or regularly sign in on hotel, airport, or coffee shop networks.',
+    href: affiliates.nordvpn.url,
+    cta: 'Try NordVPN',
+    monetized: affiliates.nordvpn.monetized,
+  },
+  {
+    title: 'Monitor exposed identity data',
+    description: 'Best fit if a breach, suspicious mail, leaked SSN, or fraud alert is already part of the situation.',
+    href: affiliates.nordprotect.url,
+    cta: 'Try NordProtect',
+    monetized: affiliates.nordprotect.monetized,
+  },
+];
+
 export default function RecommendedToolsPage() {
   const breadcrumbSchema = {
     "@context": "https://schema.org",
@@ -201,13 +226,33 @@ export default function RecommendedToolsPage() {
 
       <main className="max-w-3xl mx-auto p-6">
         <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-          Disclosure: Some links on this page are affiliate links. We may earn a small commission if you make a purchase through them, at no extra cost to you.
+          Disclosure: Some links on this page are affiliate links and some are plain editorial links. We may earn a small commission if you make a purchase through an affiliate link, at no extra cost to you.
         </div>
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-slate-800 mb-2">Recommended Security Tools</h1>
           <p className="text-slate-500 mb-3">Our curated picks for the tools that actually move the needle on your security. All listed here based on features, reputation, and real-world value.</p>
-          <p className="text-xs text-slate-400 italic">Some links on this page are affiliate links. We may earn a commission at no extra cost to you — this never influences our recommendations. <Link href="/editorial-policy" className="text-indigo-600 hover:underline">Review our editorial policy</Link>.</p>
+          <p className="text-xs text-slate-400 italic">Some links on this page are affiliate links and some are plain editorial references. We may earn a commission at no extra cost to you when you use an affiliate link, but that never determines whether a product appears here. <Link href="/editorial-policy" className="text-indigo-600 hover:underline">Review our editorial policy</Link>.</p>
         </div>
+
+        <section className="mb-8 rounded-2xl border border-slate-200 bg-white p-5 shadow-md shadow-slate-200/50">
+          <p className="mb-2 text-xs font-bold uppercase tracking-wide text-indigo-500">Best first move</p>
+          <h2 className="mb-3 text-xl font-bold text-slate-800">Buy the layer that fixes your biggest current risk</h2>
+          <div className="grid gap-3 md:grid-cols-3">
+            {firstMoveCards.map((card) => (
+              <a
+                key={card.title}
+                href={card.href}
+                target="_blank"
+                rel={card.monetized ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
+                className="rounded-xl border border-slate-200 bg-slate-50 p-4 transition hover:border-indigo-200 hover:bg-indigo-50"
+              >
+                <h3 className="mb-2 text-sm font-bold text-slate-800">{card.title}</h3>
+                <p className="mb-3 text-xs leading-relaxed text-slate-500">{card.description}</p>
+                <span className="text-xs font-bold text-indigo-600">{card.cta} →</span>
+              </a>
+            ))}
+          </div>
+        </section>
 
         <div className="mb-8">
           <AffiliateCTA product="nordpass" />
@@ -232,6 +277,24 @@ export default function RecommendedToolsPage() {
           </div>
         </section>
 
+        <section className="mb-10 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/50">
+          <h2 className="mb-3 text-lg font-bold text-slate-800">How to read this page</h2>
+          <div className="grid gap-3 text-sm text-slate-600 md:grid-cols-3">
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <p className="font-semibold text-slate-800 mb-1">Best value</p>
+              <p>Usually the product we think offers the smoothest balance of price, usability, and security for most readers.</p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <p className="font-semibold text-slate-800 mb-1">Open source or specialist picks</p>
+              <p>Included when a tool is a better fit for a specific type of reader even if it is not the default recommendation.</p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <p className="font-semibold text-slate-800 mb-1">Affiliate note</p>
+              <p>Buttons marked as affiliate links may earn us a commission. Editorial-only links stay unsponsored.</p>
+            </div>
+          </div>
+        </section>
+
         <div className="space-y-10">
           {tools.map((section) => (
             <section key={section.category}>
@@ -246,6 +309,15 @@ export default function RecommendedToolsPage() {
                           <span className="text-xs font-semibold px-2 py-0.5 rounded-full text-white" style={{ backgroundColor: tool.badgeColor }}>
                             {tool.badge}
                           </span>
+                          {tool.monetized ? (
+                            <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-amber-100 text-amber-800">
+                              Affiliate
+                            </span>
+                          ) : (
+                            <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-slate-100 text-slate-700">
+                              Editorial
+                            </span>
+                          )}
                         </div>
                         <p className="text-sm text-slate-500 font-medium">{tool.tagline}</p>
                       </div>
@@ -260,11 +332,11 @@ export default function RecommendedToolsPage() {
                     </ul>
                     <a
                       href={tool.url}
-                      rel={tool.sponsored ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
+                      rel={tool.monetized ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
                       target="_blank"
                       className="inline-block bg-gradient-to-r from-indigo-500 to-purple-600 text-white font-semibold px-5 py-2.5 rounded-xl text-sm hover:opacity-90 transition"
                     >
-                      Try {tool.name} →
+                      {tool.monetized ? `Try ${tool.name} (Affiliate)` : `Visit ${tool.name}`} →
                     </a>
                   </div>
                 ))}
@@ -298,6 +370,7 @@ export default function RecommendedToolsPage() {
           <Link href="/blog" className="hover:text-indigo-600">Blog</Link>
           <Link href="/about" className="hover:text-indigo-600">About</Link>
           <Link href="/privacy" className="hover:text-indigo-600">Privacy</Link>
+          <Link href="/terms" className="hover:text-indigo-600">Terms</Link>
         </div>
         <p>© 2026 StrongPasswordGenerator.dev · <span className="italic">Affiliate disclosure: some links earn us a commission.</span></p>
       </footer>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -65,6 +65,12 @@ const staticRoutes: MetadataRoute.Sitemap = [
     priority: 0.5,
   },
   {
+    url: `${BASE_URL}/terms`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly',
+    priority: 0.5,
+  },
+  {
     url: `${BASE_URL}/editorial-policy`,
     lastModified: new Date(),
     changeFrequency: 'monthly',

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,151 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Terms of Use | Strong Password Generator',
+  description: 'Terms of use for StrongPasswordGenerator.dev, including acceptable use, informational disclaimers, and affiliate transparency.',
+  alternates: {
+    canonical: 'https://strongpasswordgenerator.dev/terms',
+  },
+  openGraph: {
+    title: 'Terms of Use | Strong Password Generator',
+    description: 'Terms of use for StrongPasswordGenerator.dev, including acceptable use, informational disclaimers, and affiliate transparency.',
+    url: 'https://strongpasswordgenerator.dev/terms',
+    siteName: 'Strong Password Generator',
+    type: 'website',
+    images: [{ url: '/og-image.svg' }],
+  },
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
+      <header className="bg-white/80 backdrop-blur-md border-b border-slate-200/50 py-4 px-6 sticky top-0 z-10">
+        <div className="max-w-3xl mx-auto flex justify-between items-center">
+          <Link href="/" className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg">
+              <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+              </svg>
+            </div>
+            <span className="text-xl font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">SecurePass</span>
+          </Link>
+          <Link href="/" className="text-sm text-indigo-600 hover:text-indigo-800 font-medium">← Generator</Link>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto p-6">
+        <div className="bg-white rounded-3xl shadow-xl shadow-slate-200/50 p-8 border border-slate-100">
+          <h1 className="text-3xl font-bold text-slate-800 mb-2">Terms of Use</h1>
+          <p className="text-sm text-slate-400 mb-8">Last updated: July 2026</p>
+
+          <div className="space-y-8 text-slate-600 leading-relaxed">
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Acceptance of These Terms</h2>
+              <p>
+                By using StrongPasswordGenerator.dev, you agree to these terms of use. If you do not agree,
+                please do not use the site.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Educational Use Only</h2>
+              <p>
+                Our password generator, reviews, buying guides, and security articles are provided for general
+                educational and informational purposes. They do not replace legal advice, financial advice,
+                professional incident response, or support from the relevant institution involved in a breach,
+                fraud event, or account takeover.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Tool Usage and Security</h2>
+              <p>
+                The password generator runs locally in your browser. You are responsible for how you use the
+                generated passwords, where you store them, and whether you enable additional protections such
+                as two-factor authentication, passkeys, or password-manager vault security.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">No Warranty</h2>
+              <p>
+                We provide the site on an “as is” and “as available” basis without warranties of any kind.
+                We do not guarantee uninterrupted availability, absolute accuracy, or that every article,
+                product claim, or vendor detail will always remain current.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Affiliate Relationships</h2>
+              <p>
+                Some outbound links are affiliate links. If you buy through those links, we may earn a
+                commission at no additional cost to you. These relationships help support the site but do
+                not determine whether a product is included or how it is described. See our{' '}
+                <Link href="/editorial-policy" className="text-indigo-600 hover:underline">editorial policy</Link>{' '}
+                and <Link href="/privacy" className="text-indigo-600 hover:underline">privacy policy</Link> for more detail.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">External Links and Third Parties</h2>
+              <p>
+                We link to third-party services, tools, and vendor websites. We are not responsible for the
+                content, availability, pricing, claims, or privacy practices of those external sites. Review
+                their own terms and policies before relying on them.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Acceptable Use</h2>
+              <p className="mb-3">You agree not to misuse the site, including by attempting to:</p>
+              <ul className="list-disc list-inside space-y-1 text-sm">
+                <li>interfere with the site&apos;s normal operation or availability</li>
+                <li>scrape or automate access in a way that harms the service</li>
+                <li>use the site for unlawful, deceptive, or abusive activity</li>
+                <li>misrepresent our content as professional legal, financial, or security-response advice</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Limitation of Liability</h2>
+              <p>
+                To the maximum extent permitted by law, StrongPasswordGenerator.dev is not liable for any
+                indirect, incidental, or consequential damages arising from use of the site, reliance on
+                the content, or decisions made based on our guides or recommendations.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Updates to These Terms</h2>
+              <p>
+                We may update these terms as the site evolves. When changes are material, we will update the
+                date at the top of this page.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Contact</h2>
+              <p>
+                Questions about these terms? Visit our <Link href="/contact" className="text-indigo-600 hover:underline">contact page</Link>.
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
+
+      <footer className="max-w-3xl mx-auto px-6 py-8 mt-8 border-t border-slate-200 text-center text-sm text-slate-400">
+        <div className="flex justify-center gap-6 mb-3 flex-wrap">
+          <Link href="/" className="hover:text-indigo-600">Home</Link>
+          <Link href="/blog" className="hover:text-indigo-600">Blog</Link>
+          <Link href="/recommended-tools" className="hover:text-indigo-600">Tools</Link>
+          <Link href="/about" className="hover:text-indigo-600">About</Link>
+          <Link href="/privacy" className="hover:text-indigo-600">Privacy</Link>
+          <Link href="/editorial-policy" className="hover:text-indigo-600">Editorial Policy</Link>
+          <Link href="/terms" className="hover:text-indigo-600">Terms</Link>
+        </div>
+        <p>© 2026 StrongPasswordGenerator.dev</p>
+      </footer>
+    </div>
+  );
+}

--- a/src/lib/affiliates.ts
+++ b/src/lib/affiliates.ts
@@ -3,27 +3,31 @@ export const affiliates = {
     url: process.env.NEXT_PUBLIC_BITWARDEN_AFFILIATE_URL ?? "https://bitwarden.com/?utm_source=strongpasswordgenerator",
     cta: "Get Bitwarden Free",
     badge: "Most secure",
-    description: "Open-source password manager trusted by millions. Free forever."
+    description: "Open-source password manager trusted by millions. Free forever.",
+    monetized: Boolean(process.env.NEXT_PUBLIC_BITWARDEN_AFFILIATE_URL),
   },
   nordpass: {
     name: "NordPass",
     url: process.env.NEXT_PUBLIC_NORDPASS_AFFILIATE_URL ?? "https://www.kqzyfj.com/click-101754888-17262576",
     cta: "Try NordPass",
     badge: "Best value",
-    description: "Simple, fast, and secure. Made by the team behind NordVPN."
+    description: "Simple, fast, and secure. Made by the team behind NordVPN.",
+    monetized: true,
   },
   nordvpn: {
     url: process.env.NEXT_PUBLIC_NORDVPN_AFFILIATE_URL ?? "https://www.awin1.com/cread.php?awinmid=15132&awinaffid=2892161",
     cta: "Try NordVPN",
     badge: "Best for public Wi-Fi",
-    description: "Encrypt traffic on public networks and add threat protection beyond passwords."
+    description: "Encrypt traffic on public networks and add threat protection beyond passwords.",
+    monetized: true,
   },
   nordprotect: {
     url: process.env.NEXT_PUBLIC_NORDPROTECT_AFFILIATE_URL ?? "https://www.awin1.com/cread.php?awinmid=123620&awinaffid=2892161",
     cta: "Try NordProtect",
     badge: "Identity protection",
-    description: "Monitor breach exposure and get alerts before leaked credentials turn into account takeover."
-  }
+    description: "Monitor breach exposure and get alerts before leaked credentials turn into account takeover.",
+    monetized: true,
+  },
 };
 
 export type AffiliateProduct = keyof typeof affiliates;

--- a/src/lib/articleCommerce.ts
+++ b/src/lib/articleCommerce.ts
@@ -1,9 +1,12 @@
+import { affiliates } from "./affiliates";
+
 export interface CommerceCard {
   title: string;
   body: string;
   href: string;
   cta: string;
   external?: boolean;
+  monetized?: boolean;
 }
 
 export interface ArticleCommerceGuide {
@@ -30,9 +33,10 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "Upgrade to NordPass for the smoothest low-cost premium path",
         body: "The easiest paid step up if you want polished apps, unlimited active devices, and better breach reporting.",
-        href: "https://www.kqzyfj.com/click-101754888-17262576",
+        href: affiliates.nordpass.url,
         cta: "Try NordPass",
         external: true,
+        monetized: affiliates.nordpass.monetized,
       },
       {
         title: "Choose 1Password if family sharing is the reason you are paying",
@@ -65,9 +69,10 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "Choose NordPass if you want the easiest upgrade",
         body: "Best for people moving off browser autofill who want a cleaner interface and built-in breach alerts.",
-        href: "https://www.kqzyfj.com/click-101754888-17262576",
+        href: affiliates.nordpass.url,
         cta: "Try NordPass",
         external: true,
+        monetized: affiliates.nordpass.monetized,
       },
       {
         title: "Choose Bitwarden if free and open source matter most",
@@ -113,9 +118,10 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "NordPass for simpler onboarding",
         body: "A strong option if you want a cleaner interface and easier adoption for less technical relatives.",
-        href: "https://www.kqzyfj.com/click-101754888-17262576",
+        href: affiliates.nordpass.url,
         cta: "Try NordPass Family",
         external: true,
+        monetized: affiliates.nordpass.monetized,
       },
       {
         title: "Bitwarden for the lowest long-term cost",
@@ -155,9 +161,10 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "NordPass if you need SSO sooner",
         body: "A strong value if you want SSO support without jumping to a more expensive enterprise tier immediately.",
-        href: "https://www.kqzyfj.com/click-101754888-17262576",
+        href: affiliates.nordpass.url,
         cta: "Try NordPass Business",
         external: true,
+        monetized: affiliates.nordpass.monetized,
       },
       {
         title: "Bitwarden if auditability matters most",
@@ -196,9 +203,10 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "Switch to NordPass for the easiest dedicated upgrade",
         body: "Best if you want the familiar autofill experience with cleaner cross-platform support and breach alerts.",
-        href: "https://www.kqzyfj.com/click-101754888-17262576",
+        href: affiliates.nordpass.url,
         cta: "Try NordPass",
         external: true,
+        monetized: affiliates.nordpass.monetized,
       },
       {
         title: "Choose Bitwarden if you want a stronger free option",
@@ -231,16 +239,18 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "Start with NordPass if your passwords are still reused",
         body: "Best first purchase for most people because account takeover risk is usually more immediate than network interception.",
-        href: "https://www.kqzyfj.com/click-101754888-17262576",
+        href: affiliates.nordpass.url,
         cta: "Start with NordPass",
         external: true,
+        monetized: affiliates.nordpass.monetized,
       },
       {
         title: "Add NordVPN if you travel or use public Wi-Fi often",
         body: "The stronger next step if you work remotely, use coffee shop Wi-Fi, or want to reduce ISP visibility.",
-        href: "https://www.awin1.com/cread.php?awinmid=15132&awinaffid=2892161",
+        href: affiliates.nordvpn.url,
         cta: "Try NordVPN",
         external: true,
+        monetized: affiliates.nordvpn.monetized,
       },
       {
         title: "Add monitoring if a breach already happened",
@@ -273,9 +283,10 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "NordProtect for the best value bundle",
         body: "A strong fit if you want dark-web alerts, credit monitoring, and recovery coverage without paying premium-tier pricing.",
-        href: "https://www.awin1.com/cread.php?awinmid=123620&awinaffid=2892161",
+        href: affiliates.nordprotect.url,
         cta: "Try NordProtect",
         external: true,
+        monetized: affiliates.nordprotect.monetized,
       },
       {
         title: "Add a password manager next",
@@ -295,7 +306,7 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "Freeze your credit",
         body: "Still the most underused no-cost defense against new-account fraud.",
-        href: "/blog/how-to-recover-from-identity-theft",
+        href: "/blog/how-to-freeze-your-credit",
         cta: "Review freeze steps",
       },
       {
@@ -314,9 +325,10 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       {
         title: "Use NordProtect for ongoing monitoring",
         body: "Best if you want alerts, recovery support, and a simpler way to spot new exposure after the initial cleanup.",
-        href: "https://www.awin1.com/cread.php?awinmid=123620&awinaffid=2892161",
+        href: affiliates.nordprotect.url,
         cta: "Try NordProtect",
         external: true,
+        monetized: affiliates.nordprotect.monetized,
       },
       {
         title: "Replace reused passwords with a manager immediately",
@@ -344,6 +356,180 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
         body: "Use it to work through reuse, 2FA, and breach-response cleanup step by step.",
         href: "/blog/password-security",
         cta: "Open the security hub",
+      },
+    ],
+  },
+  "nordvpn-review-2026": {
+    eyebrow: "Best fit at a glance",
+    title: "Who NordVPN is best for",
+    summary: "NordVPN is strongest when you need reliable privacy on public networks, travel-friendly coverage, and a clean path into a broader security stack.",
+    cards: [
+      {
+        title: "Choose NordVPN if you use public Wi-Fi often",
+        body: "Best for travelers, remote workers, and anyone who wants a simple, audited VPN with broad device support.",
+        href: affiliates.nordvpn.url,
+        cta: "Try NordVPN",
+        external: true,
+        monetized: affiliates.nordvpn.monetized,
+      },
+      {
+        title: "Add NordPass if password reuse is still the bigger risk",
+        body: "A VPN protects traffic, but it does not fix weak or reused credentials across your accounts.",
+        href: "/blog/password-manager-vs-browser-autofill",
+        cta: "Compare password managers",
+      },
+      {
+        title: "Add NordProtect if a breach is already part of the picture",
+        body: "Identity monitoring helps when your concern has shifted from privacy to active exposure and fraud cleanup.",
+        href: "/blog/best-identity-theft-protection-2026",
+        cta: "Review identity protection",
+      },
+    ],
+    followUpTitle: "Build the rest of the stack in order",
+    followUps: [
+      {
+        title: "Secure the accounts behind your VPN",
+        body: "Strong passwords and 2FA still matter more than the network layer once you sign in.",
+        href: "/blog/password-security",
+        cta: "Open the security hub",
+      },
+      {
+        title: "See the broader tools page",
+        body: "Useful if you want one place to compare managers, monitoring, and device-security options.",
+        href: "/recommended-tools",
+        cta: "See all recommendations",
+      },
+    ],
+  },
+  "data-breach-what-to-do": {
+    eyebrow: "Breach response stack",
+    title: "Fix the exposed login first, then monitor the identity risk",
+    summary: "A data breach is not solved by one password change. Rotate the exposed account, stop reuse across related accounts, and add monitoring if personal data was exposed.",
+    cards: [
+      {
+        title: "Use NordPass to rotate exposed passwords",
+        body: "Best first step when the breach included passwords or when you are not sure where credentials were reused.",
+        href: affiliates.nordpass.url,
+        cta: "Try NordPass",
+        external: true,
+        monetized: affiliates.nordpass.monetized,
+      },
+      {
+        title: "Add NordProtect if identity data was exposed",
+        body: "A stronger fit when the breach involved your SSN, address, phone number, credit data, or other personal information.",
+        href: affiliates.nordprotect.url,
+        cta: "Try NordProtect",
+        external: true,
+        monetized: affiliates.nordprotect.monetized,
+      },
+      {
+        title: "Freeze your credit if new-account fraud is possible",
+        body: "Use the free credit-freeze steps before spending on extra monitoring if the breach exposed sensitive identity details.",
+        href: "/blog/how-to-freeze-your-credit",
+        cta: "Review freeze steps",
+      },
+    ],
+    followUpTitle: "Finish the cleanup",
+    followUps: [
+      {
+        title: "Choose a password manager",
+        body: "Compare the main manager options before replacing reused credentials.",
+        href: "/blog/password-managers",
+        cta: "Open manager guide",
+      },
+      {
+        title: "Review identity protection tools",
+        body: "Use this if the breach involved more than just an email and password.",
+        href: "/blog/best-identity-theft-protection-2026",
+        cta: "Compare monitoring options",
+      },
+    ],
+  },
+  "identity-theft-statistics-2026": {
+    eyebrow: "Risk to action",
+    title: "Turn the identity-risk data into a prevention stack",
+    summary: "The useful takeaway from identity-theft statistics is practical: reduce account takeover risk, block new-account fraud, and monitor for exposed personal data.",
+    cards: [
+      {
+        title: "Start with NordProtect for monitoring and recovery support",
+        body: "Best fit if your main concern is exposed personal data, dark-web alerts, or help responding to identity fraud.",
+        href: affiliates.nordprotect.url,
+        cta: "Try NordProtect",
+        external: true,
+        monetized: affiliates.nordprotect.monetized,
+      },
+      {
+        title: "Use NordPass to reduce account takeover risk",
+        body: "Unique passwords prevent one leaked login from turning into access to your email, bank, shopping, or work accounts.",
+        href: affiliates.nordpass.url,
+        cta: "Try NordPass",
+        external: true,
+        monetized: affiliates.nordpass.monetized,
+      },
+      {
+        title: "Freeze your credit for the strongest free defense",
+        body: "A freeze is still one of the highest-impact steps against new credit accounts opened in your name.",
+        href: "/blog/how-to-freeze-your-credit",
+        cta: "Freeze credit safely",
+      },
+    ],
+    followUpTitle: "Build the prevention routine",
+    followUps: [
+      {
+        title: "Recover from active identity theft",
+        body: "Use this if fraud has already started or you found accounts you did not open.",
+        href: "/blog/how-to-recover-from-identity-theft",
+        cta: "Open recovery checklist",
+      },
+      {
+        title: "Review the full security stack",
+        body: "Compare password, VPN, antivirus, and identity-protection options in one place.",
+        href: "/recommended-tools",
+        cta: "See recommended tools",
+      },
+    ],
+  },
+  "how-to-freeze-your-credit": {
+    eyebrow: "Freeze plus monitor",
+    title: "A credit freeze blocks new accounts; monitoring catches exposure",
+    summary: "Freezing credit is the right first move for new-account fraud risk. Pair it with password cleanup and monitoring when your personal data is already circulating.",
+    cards: [
+      {
+        title: "Freeze first if fraud is not active yet",
+        body: "Use the bureau freeze process before buying anything. It directly blocks most new-credit attempts.",
+        href: "/blog/how-to-freeze-your-credit",
+        cta: "Follow freeze steps",
+      },
+      {
+        title: "Use NordProtect for alerts and recovery support",
+        body: "Best if you want ongoing monitoring after a breach or want help spotting new exposure quickly.",
+        href: affiliates.nordprotect.url,
+        cta: "Try NordProtect",
+        external: true,
+        monetized: affiliates.nordprotect.monetized,
+      },
+      {
+        title: "Use NordPass to lock down exposed accounts",
+        body: "A freeze protects credit files. A manager helps prevent credential reuse from spreading damage across accounts.",
+        href: affiliates.nordpass.url,
+        cta: "Try NordPass",
+        external: true,
+        monetized: affiliates.nordpass.monetized,
+      },
+    ],
+    followUpTitle: "Cover the other failure modes",
+    followUps: [
+      {
+        title: "Review identity protection",
+        body: "Compare monitoring and recovery options after the freeze is in place.",
+        href: "/blog/best-identity-theft-protection-2026",
+        cta: "Compare tools",
+      },
+      {
+        title: "Handle a live incident",
+        body: "Use the recovery checklist if you already see fraudulent accounts, charges, or mail.",
+        href: "/blog/how-to-recover-from-identity-theft",
+        cta: "Start recovery",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Add Terms page and more consistent legal/footer navigation for AdSense readiness.
- Tighten affiliate disclosure, sponsored rel handling, and affiliate click classification.
- Route SPG commercial CTAs toward verified NordPass, NordVPN, and NordProtect paths while keeping Bitwarden/1Password editorial unless monetized.
- Add high-intent commerce blocks for breach, identity-theft, freeze, VPN, and password-manager content.

## Verification
- npm run lint
- npm run build

## Handoff
- Branch was rebased onto current origin/main before push.
- Lint passes with one existing warning in src/app/components/PassphraseGenerator.tsx.
- Cloudflare Pages preview passed on the initial PR run; Vercel preview failed separately and needs log inspection if Vercel remains a required deploy target.

Closes #432