### PR TITLE
fix generator trust and measurement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "tsc --noEmit false --incremental false --esModuleInterop true --module commonjs --moduleResolution node --target es2020 --outDir /tmp/spg-issue-435-tests --types node src/lib/password-generator.test.ts src/lib/privacy.test.ts src/lib/analytics.test.ts && node --test /tmp/spg-issue-435-tests/*.test.js",
     "lint": "eslint",
     "check:adsense": "node scripts/check-adsense-readiness.mjs",
     "audit:content": "node scripts/audit-content-quality.mjs"

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     description: 'Learn about StrongPasswordGenerator.dev — a free tool to generate cryptographically secure passwords and learn password security best practices.',
     images: [
       {
-        url: 'https://strongpasswordgenerator.dev/og-image.png',
+        url: 'https://strongpasswordgenerator.dev/og-image.svg',
         width: 1200,
         height: 630,
         alt: 'Strong Password Generator - About',
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'About | Strong Password Generator',
     description: 'Learn about StrongPasswordGenerator.dev — a free tool to generate cryptographically secure passwords and learn password security best practices.',
-    images: ['https://strongpasswordgenerator.dev/og-image.png'],
+    images: ['https://strongpasswordgenerator.dev/og-image.svg'],
   },
 };
 
@@ -145,8 +145,8 @@ export default function AboutPage() {
           <h2 className="text-xl font-bold text-slate-800 mb-4">How the Generator Works</h2>
           <div className="space-y-4 text-slate-600 leading-relaxed">
             <p>Passwords are generated using <strong>cryptographically secure randomness</strong> from the browser&apos;s built-in <code className="bg-slate-100 px-1 rounded text-indigo-600">crypto.getRandomValues()</code> API — the same standard used by secure applications worldwide.</p>
-            <p>Strength is calculated using <strong>Shannon entropy</strong>: the number of bits of randomness in your password given its character set and length. Crack time estimates assume a dedicated attacker running 10 billion guesses per second.</p>
-            <p>Password history is stored only in your browser&apos;s <code className="bg-slate-100 px-1 rounded text-indigo-600">localStorage</code> — it never leaves your device and is cleared when you clear browser data.</p>
+            <p>Strength and crack-time labels are rough theoretical estimates based on length, detected character classes, and an assumed 10 billion guesses per second. They cannot identify every predictable pattern, reused password, leak, or attacker-specific clue.</p>
+            <p>Generated passwords are not persisted or placed in a password history. The site stores only generator preferences, such as length and enabled character classes, in your browser&apos;s <code className="bg-slate-100 px-1 rounded text-indigo-600">localStorage</code>.</p>
           </div>
         </div>
 

--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -23,6 +23,15 @@ export default function Analytics() {
       ) : null}
       <Script id="income-click-tracking" strategy="afterInteractive">
         {`
+          function funnelEvent(action, placement, extra) {
+            if (!window.gtag) return;
+            window.gtag('event', action, Object.assign({
+              action: action,
+              page: window.location.pathname,
+              placement: placement
+            }, extra || {}));
+          }
+
           document.addEventListener('click', function(event) {
             var link = event.target && event.target.closest ? event.target.closest('a[href]') : null;
             if (!link || !window.gtag) return;
@@ -45,13 +54,33 @@ export default function Analytics() {
             else if (/awin1/i.test(href)) partner = 'awin';
 
             if (isAffiliate || isExternal) {
-              window.gtag('event', isAffiliate ? 'affiliate_click' : 'outbound_click', {
-                link_url: link.href,
-                link_domain: url.hostname,
-                affiliate_partner: isAffiliate ? partner : undefined,
-                link_text: (link.textContent || '').trim().slice(0, 100),
-                page_location: window.location.href
-              });
+              var placement = link.closest('main') ? 'content' : link.closest('footer') ? 'footer' : 'site_navigation';
+              if (isAffiliate) {
+                funnelEvent('affiliate_click', placement, { partner: partner });
+              } else {
+                funnelEvent('outbound_click', placement, { link_domain: url.hostname });
+              }
+            }
+          });
+
+          var seenRecommendations = new WeakSet();
+          var observer = new IntersectionObserver(function(entries) {
+            entries.forEach(function(entry) {
+              if (!entry.isIntersecting || seenRecommendations.has(entry.target)) return;
+              seenRecommendations.add(entry.target);
+              var isNewsletter = entry.target.tagName === 'IFRAME';
+              funnelEvent(isNewsletter ? 'newsletter_view' : 'recommendation_view', isNewsletter ? 'homepage_newsletter' : 'affiliate_cta');
+            });
+          }, { threshold: 0.5 });
+
+          document.querySelectorAll('a[rel~="sponsored"], iframe[title="Security newsletter signup"]').forEach(function(element) {
+            observer.observe(element);
+          });
+
+          window.addEventListener('blur', function() {
+            var active = document.activeElement;
+            if (active && active.tagName === 'IFRAME' && active.title === 'Security newsletter signup') {
+              funnelEvent('newsletter_action', 'homepage_newsletter');
             }
           });
         `}

--- a/src/app/components/PassphraseGenerator.tsx
+++ b/src/app/components/PassphraseGenerator.tsx
@@ -1,5 +1,7 @@
 'use client';
 import { useState, useCallback, useEffect } from 'react';
+import { generateSecurePassphrase } from '@/lib/password-generator';
+import { trackFunnelEvent } from '@/lib/analytics';
 
 const WORDS = [
   'apple','brave','cloud','dance','eagle','flame','grace','honor','ivory','joker',
@@ -18,12 +20,6 @@ const WORDS = [
   'equip','fixed','grant','handy','image','jumbo','kinky','lucid','muted','novel',
 ];
 
-function getRandWord(): string {
-  const arr = new Uint32Array(1);
-  crypto.getRandomValues(arr);
-  return WORDS[arr[0] % WORDS.length];
-}
-
 export default function PassphraseGenerator() {
   const [wordCount, setWordCount] = useState(4);
   const [separator, setSeparator] = useState('-');
@@ -31,17 +27,17 @@ export default function PassphraseGenerator() {
   const [copied, setCopied] = useState(false);
 
   const generate = useCallback(() => {
-    const words: string[] = [];
-    for (let i = 0; i < wordCount; i++) words.push(getRandWord());
-    setPassphrase(words.join(separator));
+    setPassphrase(generateSecurePassphrase(WORDS, wordCount, separator));
+    trackFunnelEvent({ action: 'generator_success', page: '/', placement: 'passphrase_generator', generator: 'passphrase' });
   }, [wordCount, separator]);
 
-  const copy = async () => {
+  const copy = useCallback(async () => {
     if (!passphrase) return;
     await navigator.clipboard.writeText(passphrase);
+    trackFunnelEvent({ action: 'copy', page: '/', placement: 'passphrase_generator', generator: 'passphrase' });
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
-  };
+  }, [passphrase]);
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if ((event.ctrlKey || event.metaKey) && event.key === 'c') {
@@ -93,7 +89,10 @@ export default function PassphraseGenerator() {
               className={`bg-slate-100 hover:bg-slate-200 text-slate-700 font-semibold px-5 py-2.5 rounded-lg text-sm transition flex-1 sm:flex-none ${copied ? 'bg-green-200' : ''}`}>
               Copy Password
             </button>
-            <button onClick={generate}
+            <button onClick={() => {
+              trackFunnelEvent({ action: 'regenerate', page: '/', placement: 'passphrase_generator', generator: 'passphrase' });
+              generate();
+            }}
               aria-label="Generate new passphrase"
               className="bg-[#00d4aa] hover:bg-[#00b894] text-black font-semibold px-5 py-2.5 rounded-lg text-sm transition flex-1 sm:flex-none">
               Generate New
@@ -116,7 +115,7 @@ export default function PassphraseGenerator() {
 
       {passphrase && (
         <p id="passphrase-value" className="text-xs text-slate-400">
-          Entropy: ~{Math.round(wordCount * Math.log2(WORDS.length))} bits · Crack time at 10B guesses/sec: centuries+
+          Rough theoretical entropy estimate: ~{Math.round(wordCount * Math.log2(WORDS.length))} bits. This assumes independent random word choices; do not substitute your own predictable words.
         </p>
       )}
     </div>

--- a/src/app/components/PasswordChecker.tsx
+++ b/src/app/components/PasswordChecker.tsx
@@ -33,11 +33,11 @@ function calculateStrength(pwd: string): { score: number; label: string } {
   const entropy = calculateEntropy(pwd);
 
   if (pwd.length === 0) return { score: 0, label: '' };
-  if (entropy < 28) return { score: 1, label: 'Very Weak' };
-  if (entropy < 36) return { score: 2, label: 'Weak' };
-  if (entropy < 60) return { score: 3, label: 'Fair' };
-  if (entropy < 80) return { score: 4, label: 'Strong' };
-  return { score: 5, label: 'Very Strong' };
+  if (entropy < 28) return { score: 1, label: 'Very low estimate' };
+  if (entropy < 36) return { score: 2, label: 'Low estimate' };
+  if (entropy < 60) return { score: 3, label: 'Moderate estimate' };
+  if (entropy < 80) return { score: 4, label: 'High estimate' };
+  return { score: 5, label: 'Very high estimate' };
 }
 
 export default function PasswordChecker() {
@@ -98,7 +98,7 @@ export default function PasswordChecker() {
       {password.length > 0 && (
         <div aria-live="polite" className="space-y-3 rounded-xl border border-slate-100 bg-slate-50 p-4">
           <div className="flex justify-between text-sm">
-            <span className="text-slate-500">Strength:</span>
+            <span className="text-slate-500">Theoretical strength estimate:</span>
             <span style={{ color: getStrengthColor() }}>{strengthLabel}</span>
           </div>
           <div role="progressbar" aria-valuenow={strengthScore} aria-valuemin={0} aria-valuemax={5} aria-valuetext={strengthLabel || 'No password entered'} className="h-2 bg-slate-50 rounded-full overflow-hidden">
@@ -112,9 +112,10 @@ export default function PasswordChecker() {
               Entropy: <span className="text-slate-700">{Math.round(entropy)} bits</span>
             </div>
             <div>
-              Estimated crack time: <span className="text-slate-700">{crackTime}</span>
+              Rough theoretical crack time: <span className="text-slate-700">{crackTime}</span>
             </div>
           </div>
+          <p className="text-xs text-slate-400">This calculation assumes random character selection and 10 billion guesses per second. It cannot detect every word, pattern, reused password, breach, or attacker-specific clue.</p>
         </div>
       )}
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,8 @@ import "./globals.css";
 export const metadata: Metadata = {
   metadataBase: new URL("https://strongpasswordgenerator.dev"),
   title: "Strong Password Generator | Free Security Suite",
-  description: "Free password generator with advanced security analysis. Generate cryptographically secure passwords, check strength, estimate crack time, and monitor password health.",
-  keywords: "password generator, password strength, security checker, password health, cryptographically secure, password entropy, crack time calculator",
+  description: "Generate random passwords locally with Web Crypto and review clearly labeled theoretical strength estimates.",
+  keywords: "password generator, password strength estimate, cryptographically secure, password entropy, crack time estimate",
   alternates: {
     canonical: "/",
   },
@@ -69,7 +69,7 @@ export default function RootLayout({
               "@type": "WebApplication",
               "name": "Strong Password Generator",
               "url": "https://strongpasswordgenerator.dev",
-              "description": "Free online password generator with cryptographic security analysis, strength checking, breach monitoring, and password health dashboard.",
+              "description": "Free online password generator that uses Web Crypto locally and provides theoretical strength estimates.",
               "applicationCategory": "SecurityApplication",
               "operatingSystem": "Web",
               "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,9 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import Script from 'next/script'; // Added Script import
 import { Suspense, useState, useEffect, useCallback } from 'react';
+import { generateSecurePassword } from '@/lib/password-generator';
+import { removeLegacyPasswordHistory } from '@/lib/privacy';
+import { trackFunnelEvent } from '@/lib/analytics';
 
 interface PasswordOptions {
   length: number;
@@ -17,19 +20,6 @@ interface PasswordOptions {
   numbers: boolean;
   symbols: boolean;
 }
-
-interface PasswordHistory {
-  password: string;
-  timestamp: Date | string;
-  strength: string;
-}
-
-const CHAR_SETS = {
-  uppercase: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-  lowercase: 'abcdefghijklmnopqrstuvwxyz',
-  numbers: '0123456789',
-  symbols: '!@#$%^&*()_+-=[]{}|;:,.<>?'
-};
 
 const DEFAULT_OPTIONS: PasswordOptions = {
   length: 20,
@@ -86,7 +76,7 @@ const FAQ_ITEMS = [
   },
   {
     question: "What makes a password strong?",
-    answer: "A strong password is at least 16 characters long, combines uppercase and lowercase letters, numbers, and symbols, and is unique to each account."
+    answer: "Prefer a long, unique password produced by a cryptographically secure random generator. Character variety helps only when the password is not based on a predictable word or pattern."
   },
   {
     question: "How many passwords should I generate before using one?",
@@ -117,7 +107,6 @@ function PasswordGeneratorPage() {
   const [strengthLabel, setStrengthLabel] = useState('');
   const [entropy, setEntropy] = useState(0);
   const [crackTime, setCrackTime] = useState('');
-  const [history, setHistory] = useState<PasswordHistory[]>([]);
   const [copied, setCopied] = useState(false);
 
   // Effect to save options to localStorage whenever they change
@@ -160,31 +149,15 @@ function PasswordGeneratorPage() {
     const entropy = calculateEntropy(pwd);
 
     if (pwd.length === 0) return { score: 0, label: '' };
-    if (entropy < 28) return { score: 1, label: 'Very Weak' };
-    if (entropy < 36) return { score: 2, label: 'Weak' };
-    if (entropy < 60) return { score: 3, label: 'Fair' };
-    if (entropy < 80) return { score: 4, label: 'Strong' };
-    return { score: 5, label: 'Very Strong' };
+    if (entropy < 28) return { score: 1, label: 'Very low estimate' };
+    if (entropy < 36) return { score: 2, label: 'Low estimate' };
+    if (entropy < 60) return { score: 3, label: 'Moderate estimate' };
+    if (entropy < 80) return { score: 4, label: 'High estimate' };
+    return { score: 5, label: 'Very high estimate' };
   }, [calculateEntropy]);
 
   const generatePassword = useCallback(() => {
-    let charset = '';
-    if (options.uppercase) charset += CHAR_SETS.uppercase;
-    if (options.lowercase) charset += CHAR_SETS.lowercase;
-    if (options.numbers) charset += CHAR_SETS.numbers;
-    if (options.symbols) charset += CHAR_SETS.symbols;
-
-    if (charset === '') {
-      charset = CHAR_SETS.lowercase;
-    }
-
-    let pwd = '';
-    const array = new Uint32Array(options.length);
-    crypto.getRandomValues(array);
-
-    for (let i = 0; i < options.length; i++) {
-      pwd += charset[array[i] % charset.length];
-    }
+    const pwd = generateSecurePassword(options);
 
     setPassword(pwd);
 
@@ -194,40 +167,19 @@ function PasswordGeneratorPage() {
     setStrengthLabel(strengthResult.label);
     setEntropy(Math.round(entropy));
     setCrackTime(estimateCrackTime(entropy));
-
-    setHistory(prev => {
-      const newHistory = [
-        { password: pwd, timestamp: new Date(), strength: strengthResult.label },
-        ...prev.slice(0, 9)
-      ];
-      localStorage.setItem('passwordHistory', JSON.stringify(newHistory));
-      return newHistory;
+    trackFunnelEvent({
+      action: 'generator_success',
+      page: '/',
+      placement: 'primary_generator',
+      generator: 'password',
     });
   }, [options, calculateEntropy, calculateStrength, estimateCrackTime]);
 
   const copyToClipboard = async () => {
     await navigator.clipboard.writeText(password);
+    trackFunnelEvent({ action: 'copy', page: '/', placement: 'primary_generator', generator: 'password' });
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
-  };
-
-  const exportHistory = () => {
-    const text = history
-      .map((item) => {
-        const timestamp = new Date(item.timestamp).toLocaleString();
-        return `[${timestamp}] ${item.password} (${item.strength})`;
-      })
-      .join('\n');
-
-    const blob = new Blob([text], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'password-history.txt';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
   };
 
   const getStrengthColor = () => {
@@ -237,10 +189,7 @@ function PasswordGeneratorPage() {
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      const saved = localStorage.getItem('passwordHistory');
-      if (saved) {
-        setHistory(JSON.parse(saved));
-      }
+      removeLegacyPasswordHistory(localStorage);
       generatePassword();
     }, 0);
 
@@ -258,6 +207,7 @@ function PasswordGeneratorPage() {
 
       if (event.code === 'Space') {
         event.preventDefault(); // Prevent page scroll
+        trackFunnelEvent({ action: 'regenerate', page: '/', placement: 'keyboard_shortcut', generator: 'password' });
         generatePassword();
       } else if (
         event.key.toLowerCase() === 'c' &&
@@ -265,6 +215,7 @@ function PasswordGeneratorPage() {
       ) {
         event.preventDefault();
         navigator.clipboard.writeText(password);
+        trackFunnelEvent({ action: 'copy', page: '/', placement: 'keyboard_shortcut', generator: 'password' });
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       }
@@ -379,7 +330,10 @@ function PasswordGeneratorPage() {
               symbols={options.symbols}
             />
             <button
-              onClick={generatePassword}
+              onClick={() => {
+                trackFunnelEvent({ action: 'regenerate', page: '/', placement: 'primary_generator', generator: 'password' });
+                generatePassword();
+              }}
               className="bg-[#00d4aa] hover:bg-[#00b894] text-black font-semibold px-6 py-3 rounded-lg transition"
             >
               🎲 Generate
@@ -408,7 +362,8 @@ function PasswordGeneratorPage() {
 
           {password && (
             <div className="text-sm text-slate-500">
-              ⏱️ Estimated crack time: <span className="text-white">{crackTime}</span>
+              ⏱️ Rough theoretical crack-time estimate: <span className="text-slate-700">{crackTime}</span>
+              <span className="block text-xs text-slate-400">Assumes random generation and 10 billion guesses/second; patterns, reuse, breaches, and attacker knowledge can make a password much easier to guess.</span>
             </div>
           )}
         </div>
@@ -455,43 +410,6 @@ function PasswordGeneratorPage() {
           </div>
         </div>
 
-        {/* Password History */}
-        {history.length > 0 && (
-          <div className="bg-white rounded-3xl shadow-xl shadow-slate-200/50 p-6 border border-slate-100">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-lg font-semibold">📝 Password History</h2>
-              <div className="flex items-center gap-3">
-                <button
-                  onClick={exportHistory}
-                  className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
-                >
-                  Download history
-                </button>
-                <button
-                  onClick={() => {
-                    setHistory([]);
-                    localStorage.removeItem('passwordHistory');
-                  }}
-                  className="text-sm text-slate-500 hover:text-white"
-                >
-                  Clear
-                </button>
-              </div>
-            </div>
-            <div className="space-y-2 max-h-48 overflow-y-auto">
-              {history.map((item, i) => (
-                <div
-                  key={i}
-                  className="flex justify-between items-center bg-slate-50 px-4 py-2 rounded font-mono text-sm"
-                >
-                  <span className="text-indigo-600 truncate max-w-xs">{item.password}</span>
-                  <span className="text-slate-500 text-xs">{item.strength}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
         {/* Password Security Tips */}
         <div className="bg-white rounded-3xl shadow-xl shadow-slate-200/50 p-6 border border-slate-100">
           <h2 className="text-lg font-semibold mb-4">🛡️ Password Security Tips</h2>
@@ -526,7 +444,7 @@ function PasswordGeneratorPage() {
         <div className="bg-white rounded-3xl shadow-xl shadow-slate-200/50 p-6 border border-slate-100">
           <h2 className="text-lg font-semibold mb-4">📊 What is Password Entropy?</h2>
           <div className="text-slate-500 space-y-3">
-            <p>Password entropy measures how hard a password is to guess. It&apos;s measured in <strong className="text-white">bits</strong> - the higher the number, the stronger the password.</p>
+            <p>This entropy display is a rough theoretical estimate for randomly generated passwords. It does not detect words, patterns, reuse, leaks, or personal information, so it must not be treated as a guarantee.</p>
             <ul className="list-disc list-inside space-y-2 text-sm">
               <li><span className="text-[#ff6b6b]">Less than 28 bits:</span> Very Weak - Can be cracked instantly</li>
               <li><span className="text-[#feca57]">28-35 bits:</span> Weak - Vulnerable to fast attacks</li>
@@ -534,7 +452,7 @@ function PasswordGeneratorPage() {
               <li><span className="text-[#26de81]">60-79 bits:</span> Strong - Good for most accounts</li>
               <li><span className="text-[#26de81]">80+ bits:</span> Very Strong - Excellent security</li>
             </ul>
-            <p className="text-sm mt-4">This generator creates passwords with <strong className="text-white">80+ bits of entropy</strong> by default - practically uncrackable!</p>
+            <p className="text-sm mt-4">Long, unique, randomly generated passwords are generally harder to guess. Store each one in a reputable password manager and enable multi-factor authentication where available.</p>
           </div>
         </div>
 
@@ -543,7 +461,8 @@ function PasswordGeneratorPage() {
           <h2 className="text-lg font-semibold mb-4">ℹ️ About This Tool</h2>
           <div className="text-slate-500 text-sm space-y-2">
             <p>This password generator creates cryptographically secure passwords using your browser&apos;s built-in <strong className="text-white">crypto.getRandomValues()</strong> API - the same technology used by password managers and security professionals.</p>
-            <p>All passwords are generated <strong className="text-white">locally on your device</strong>. Nothing is ever sent to any server.</p>
+            <p>Generation happens <strong>locally on your device</strong>. Generated passwords are not sent to us, saved to local storage, or retained in a password history.</p>
+            <p>Strength and crack-time labels are theoretical estimates, not security guarantees. They cannot recognize every predictable pattern or account for leaks and reuse.</p>
           </div>
         </div>
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -49,7 +49,7 @@ export default function PrivacyPage() {
                 name: 'Do you see the passwords I generate?',
                 acceptedAnswer: {
                   '@type': 'Answer',
-                  text: 'No, we never see the passwords you generate. Password generation happens entirely in your browser, using your browser\'s crypto.getRandomValues() API. Generated passwords are never transmitted to our servers, never logged, and never stored anywhere except optionally in your own browser\'s localStorage.',
+                  text: 'No. Password generation happens entirely in your browser using the Web Crypto API. Generated passwords are not transmitted to us, logged, or saved in localStorage. The site removes legacy passwordHistory data when the generator loads.',
                 },
               },
               {
@@ -65,7 +65,7 @@ export default function PrivacyPage() {
                 name: 'How do you use cookies and local storage?',
                 acceptedAnswer: {
                   '@type': 'Answer',
-                  text: 'We use browser localStorage to save your password generator preferences (length, character options) and password history between sessions. This data stays on your device and is never sent to us. We may also use cookies for analytics purposes, which you can disable in your browser settings.',
+                  text: 'We use browser localStorage only to save generator preferences such as length and character options. Generated passwords are not stored. Analytics and advertising providers may use cookies, subject to their policies and your browser controls.',
                 },
               },
             ],
@@ -105,7 +105,7 @@ export default function PrivacyPage() {
             <section>
               <h2 className="text-xl font-bold text-slate-800 mb-3">The Short Version</h2>
               <div className="bg-indigo-50 border border-indigo-100 rounded-xl p-4 text-sm">
-                <p>We never see the passwords you generate. Password generation happens entirely in your browser. We collect standard analytics (page views, referrers) but no personally identifiable information. Password history is stored locally on your device only.</p>
+                <p>We never see the passwords you generate. Generation happens entirely in your browser, and generated values are not persisted. We collect aggregate site and funnel analytics, but those events never include generated or checked passwords.</p>
               </div>
             </section>
 
@@ -114,14 +114,14 @@ export default function PrivacyPage() {
               <ul className="list-disc list-inside space-y-2 text-slate-600 leading-relaxed">
                 <li><strong>Your Passwords are Private:</strong> All password generation happens directly in your browser and is never sent to our servers.</li>
                 <li><strong>Minimal Data Collection:</strong> We collect non-identifying analytics data (like page views) but no personal information unless you contact us directly.</li>
-                <li><strong>Local Storage for Preferences:</strong> Your password history and generator settings are saved only on your device using browser local storage.</li>
+                <li><strong>Local Storage for Preferences:</strong> Generator settings are saved on your device. Generated passwords are not saved, and legacy password-history data is removed when the generator loads.</li>
                 <li><strong>Transparency on Third-Parties:</strong> We use services like Google Analytics and AdSense, and some links are affiliates, all disclosed in detail.</li>
               </ul>
             </section>
 
             <section>
               <h2 className="text-xl font-bold text-slate-800 mb-3">Password Generation</h2>
-              <p>All passwords are generated client-side using your browser&apos;s <code className="bg-slate-100 px-1 rounded text-indigo-700">crypto.getRandomValues()</code> API. Generated passwords are never transmitted to our servers, never logged, and never stored anywhere except optionally in your own browser&apos;s localStorage.</p>
+              <p>All passwords are generated client-side using your browser&apos;s <code className="bg-slate-100 px-1 rounded text-indigo-700">crypto.getRandomValues()</code> API. Generated passwords are not transmitted to us, logged, or saved in localStorage. When the generator loads, it removes any <code className="bg-slate-100 px-1 rounded text-indigo-700">passwordHistory</code> data created by an earlier version.</p>
             </section>
 
             <section>
@@ -131,15 +131,20 @@ export default function PrivacyPage() {
                 <li>Page views and general site analytics (via Google Analytics or hosting-provider analytics)</li>
                 <li>Referring URLs and general geographic region (country-level)</li>
                 <li>Browser type and device type (for compatibility)</li>
-                <li>Affiliate and outbound link click events, reviewed in aggregate</li>
+                <li>Generator success, copy, regenerate, recommendation view, affiliate click, and newsletter interaction events, with page and placement context</li>
               </ul>
               <p className="mt-3 text-sm">We do not collect names, email addresses, or any personally identifiable information unless you choose to contact us.</p>
             </section>
 
             <section>
               <h2 className="text-xl font-bold text-slate-800 mb-3">Cookies & Local Storage</h2>
-              <p>We use browser localStorage to save your password generator preferences (length, character options) and password history between sessions. This data stays on your device and is never sent to us. You can clear it at any time by clearing your browser&apos;s site data.</p>
+              <p>We use browser localStorage to save only password generator preferences such as length and character options. We do not save generated passwords or a password history. You can remove preferences by clearing this site&apos;s browser data.</p>
               <p className="mt-2">We may use cookies for analytics purposes. You can disable cookies in your browser settings.</p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-slate-800 mb-3">Funnel Analytics</h2>
+              <p>We measure whether a generator succeeds and whether visitors copy, regenerate, view a recommendation, follow an affiliate link, or interact with the newsletter form. Event payloads include the action, page, placement, and—when relevant—the generator type or affiliate partner. They never include a generated password, passphrase, or password-checker input.</p>
             </section>
 
             <section>

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildFunnelEvent } from './analytics';
+
+test('analytics payload exposes only defined, non-secret context', () => {
+  const unsafeInput = {
+    action: 'copy' as const,
+    page: '/',
+    placement: 'primary_generator',
+    generator: 'password' as const,
+    password: 'Never-collect-this-secret',
+  };
+  const payload = buildFunnelEvent(unsafeInput);
+  assert.deepEqual(payload, { action: 'copy', page: '/', placement: 'primary_generator', generator: 'password' });
+  assert.equal(JSON.stringify(payload).includes('Never-collect'), false);
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,32 @@
+export type FunnelAction =
+  | 'generator_success'
+  | 'copy'
+  | 'regenerate'
+  | 'recommendation_view'
+  | 'affiliate_click'
+  | 'newsletter_view'
+  | 'newsletter_action';
+
+export interface FunnelEventContext {
+  action: FunnelAction;
+  page: string;
+  placement: string;
+  generator?: 'password' | 'passphrase';
+  partner?: string;
+}
+
+export function buildFunnelEvent(context: FunnelEventContext): FunnelEventContext {
+  return {
+    action: context.action,
+    page: context.page,
+    placement: context.placement,
+    ...(context.generator ? { generator: context.generator } : {}),
+    ...(context.partner ? { partner: context.partner } : {}),
+  };
+}
+
+export function trackFunnelEvent(context: FunnelEventContext): void {
+  if (typeof window === 'undefined') return;
+  const gtag = (window as Window & { gtag?: (command: string, name: string, payload: FunnelEventContext) => void }).gtag;
+  gtag?.('event', context.action, buildFunnelEvent(context));
+}

--- a/src/lib/password-generator.test.ts
+++ b/src/lib/password-generator.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { CHARACTER_SETS, generateSecurePassphrase, generateSecurePassword, secureRandomIndex } from './password-generator';
+
+function sequenceRandom(...values: number[]) {
+  let index = 0;
+  return (target: Uint32Array) => {
+    target[0] = values[index++] ?? 0;
+    return target;
+  };
+}
+
+test('rejection sampling discards values outside an even sampling range', () => {
+  const random = sequenceRandom(0xffffffff, 7);
+  assert.equal(secureRandomIndex(10, random), 7);
+});
+
+test('generated passwords contain every enabled character class', () => {
+  const password = generateSecurePassword({ length: 16, uppercase: true, lowercase: true, numbers: true, symbols: true }, sequenceRandom());
+  assert.equal(password.length, 16);
+  assert.match(password, /[A-Z]/);
+  assert.match(password, /[a-z]/);
+  assert.match(password, /[0-9]/);
+  assert.ok([...password].some((character) => CHARACTER_SETS.symbols.includes(character)));
+});
+
+test('no selected character classes falls back to lowercase', () => {
+  const password = generateSecurePassword({ length: 8, uppercase: false, lowercase: false, numbers: false, symbols: false }, sequenceRandom());
+  assert.match(password, /^[a-z]{8}$/);
+});
+
+test('passphrases use the same unbiased selector for every word', () => {
+  const passphrase = generateSecurePassphrase(['alpha', 'bravo', 'charlie'], 3, '-', sequenceRandom(0xffffffff, 0, 1, 2));
+  assert.equal(passphrase, 'alpha-bravo-charlie');
+});

--- a/src/lib/password-generator.ts
+++ b/src/lib/password-generator.ts
@@ -1,0 +1,77 @@
+export const CHARACTER_SETS = {
+  uppercase: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  lowercase: 'abcdefghijklmnopqrstuvwxyz',
+  numbers: '0123456789',
+  symbols: '!@#$%^&*()_+-=[]{}|;:,.<>?',
+} as const;
+
+export interface GeneratorOptions {
+  length: number;
+  uppercase: boolean;
+  lowercase: boolean;
+  numbers: boolean;
+  symbols: boolean;
+}
+
+export type RandomValues = (values: Uint32Array) => Uint32Array;
+
+const webCryptoRandomValues: RandomValues = (values) => crypto.getRandomValues(values);
+
+export function secureRandomIndex(upperBound: number, randomValues: RandomValues = webCryptoRandomValues): number {
+  if (!Number.isSafeInteger(upperBound) || upperBound < 1 || upperBound > 0x100000000) {
+    throw new RangeError('upperBound must be an integer between 1 and 2^32');
+  }
+
+  const range = 0x100000000;
+  const rejectionLimit = Math.floor(range / upperBound) * upperBound;
+  const sample = new Uint32Array(1);
+
+  do {
+    randomValues(sample);
+  } while (sample[0] >= rejectionLimit);
+
+  return sample[0] % upperBound;
+}
+
+export function secureChoice<T>(values: ArrayLike<T>, randomValues: RandomValues = webCryptoRandomValues): T {
+  if (values.length === 0) throw new RangeError('Cannot select from an empty collection');
+  return values[secureRandomIndex(values.length, randomValues)];
+}
+
+export function secureShuffle<T>(values: readonly T[], randomValues: RandomValues = webCryptoRandomValues): T[] {
+  const shuffled = [...values];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = secureRandomIndex(index + 1, randomValues);
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+  return shuffled;
+}
+
+export function generateSecurePassword(options: GeneratorOptions, randomValues: RandomValues = webCryptoRandomValues): string {
+  const selectedSets = (Object.keys(CHARACTER_SETS) as Array<keyof typeof CHARACTER_SETS>)
+    .filter((key) => options[key])
+    .map((key) => CHARACTER_SETS[key]);
+  const activeSets = selectedSets.length > 0 ? selectedSets : [CHARACTER_SETS.lowercase];
+
+  if (!Number.isSafeInteger(options.length) || options.length < activeSets.length) {
+    throw new RangeError('Password length must fit every enabled character class');
+  }
+
+  const characters = activeSets.map((set) => secureChoice(set, randomValues));
+  const combinedSet = activeSets.join('');
+  while (characters.length < options.length) {
+    characters.push(secureChoice(combinedSet, randomValues));
+  }
+
+  return secureShuffle(characters, randomValues).join('');
+}
+
+export function generateSecurePassphrase(
+  words: readonly string[],
+  wordCount: number,
+  separator: string,
+  randomValues: RandomValues = webCryptoRandomValues,
+): string {
+  if (!Number.isSafeInteger(wordCount) || wordCount < 1) throw new RangeError('wordCount must be positive');
+  return Array.from({ length: wordCount }, () => secureChoice(words, randomValues)).join(separator);
+}

--- a/src/lib/privacy.test.ts
+++ b/src/lib/privacy.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { removeLegacyPasswordHistory } from './privacy';
+
+test('legacy plaintext password history is removed', () => {
+  const removed: string[] = [];
+  removeLegacyPasswordHistory({ removeItem: (key) => removed.push(key) });
+  assert.deepEqual(removed, ['passwordHistory']);
+});

--- a/src/lib/privacy.ts
+++ b/src/lib/privacy.ts
@@ -1,0 +1,7 @@
+export interface StorageCleanupTarget {
+  removeItem(key: string): void;
+}
+
+export function removeLegacyPasswordHistory(storage: StorageCleanupTarget): void {
+  storage.removeItem('passwordHistory');
+}


### PR DESCRIPTION
## What changed

- removes persisted password history and plaintext export
- deletes legacy `passwordHistory` browser storage on generator load
- replaces modulo selection with rejection sampling, guarantees selected character classes, and securely shuffles output
- uses the unbiased selector for passphrases
- qualifies entropy and crack-time labels as theoretical estimates
- removes unsupported metadata claims and corrects the About-page share asset
- adds privacy-safe funnel events without collecting generated or checked passwords
- updates About and Privacy copy to match the product's behavior
- adds six dependency-free focused tests

## Why

The site claimed privacy and cryptographic-quality behavior while persisting generated secrets, using biased modulo selection, and advertising unsupported features in structured metadata. Those defects undermine user trust and AdSense quality while leaving the affiliate funnel unmeasurable.

## User impact

Generated passwords are no longer retained, random selection is implemented without modulo bias, security estimates are presented honestly, and key generator-to-recommendation actions can be measured without exposing secrets.

## Validation

- `npm test` — 6/6 passed
- `npm run lint` — zero warnings or errors
- `npm run build` — passed; 94 static routes generated
- `git diff --check`

Closes #435
