### PR TITLE
make article monetization selective

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import AffiliateCTA from '../../components/AffiliateCTA';
 import MoneyNextStep from '../../components/MoneyNextStep';
-import NordPassCTA from '../../components/NordPassCTA';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import fs from 'fs';
@@ -67,9 +66,7 @@ const nordVpnRecommendedSlugs = new Set([
   'password-security-for-remote-workers',
 ]);
 
-function getAffiliateProduct(post: PostData): 'bitwarden' | 'nordpass' | 'nordvpn' | 'nordprotect' {
-  const topicText = `${post.slug} ${post.category} ${post.tags.join(' ')} ${post.title}`.toLowerCase();
-
+function getAffiliateProduct(post: PostData): 'nordpass' | 'nordvpn' | 'nordprotect' | null {
   if (nordVpnRecommendedSlugs.has(post.slug)) {
     return 'nordvpn';
   }
@@ -78,31 +75,11 @@ function getAffiliateProduct(post: PostData): 'bitwarden' | 'nordpass' | 'nordvp
     return 'nordprotect';
   }
 
-  if (topicText.includes('vpn') || topicText.includes('wifi') || topicText.includes('remote work')) {
-    return 'nordvpn';
-  }
-
-  if (
-    topicText.includes('identity') ||
-    topicText.includes('breach') ||
-    topicText.includes('dark web') ||
-    topicText.includes('credit') ||
-    topicText.includes('hacked')
-  ) {
-    return 'nordprotect';
-  }
-
-  if (
-    topicText.includes('nordpass') ||
-    topicText.includes('password manager') ||
-    topicText.includes('browser autofill') ||
-    topicText.includes('lastpass') ||
-    topicText.includes('dashlane')
-  ) {
+  if (nordPassRecommendedSlugs.has(post.slug)) {
     return 'nordpass';
   }
 
-  return 'nordpass';
+  return null;
 }
 
 export async function generateStaticParams() {
@@ -195,8 +172,9 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
             "datePublished": post.date,
             "dateModified": post.date,
             "author": {
-              "@type": "Person",
+              "@type": "Organization",
               "name": "Strong Password Generator",
+              "url": SITE_URL,
             },
           })
         }}
@@ -221,20 +199,6 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
         />
       )}
 
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            "@context": "https://schema.org",
-            "@type": "BreadcrumbList",
-            "itemListElement": [
-              { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://strongpasswordgenerator.dev" },
-              { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://strongpasswordgenerator.dev/blog" },
-              { "@type": "ListItem", "position": 3, "name": post.title, "item": `https://strongpasswordgenerator.dev/blog/${slug}` },
-            ],
-          })
-        }}
-      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
@@ -286,14 +250,21 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
                     <h3 className="text-sm font-bold text-slate-800">{card.title}</h3>
                     <p className="mt-2 text-sm leading-relaxed text-slate-600">{card.body}</p>
                     {card.external ? (
-                      <a
-                        href={card.href}
-                        target="_blank"
-                        rel={card.monetized ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
-                        className="mt-4 inline-block text-sm font-semibold text-amber-700 hover:underline"
-                      >
-                        {card.cta} →
-                      </a>
+                      <>
+                        {card.monetized && (
+                          <p className="mt-4 text-xs leading-relaxed text-slate-500">
+                            Affiliate disclosure: we may earn a commission if you buy through this link, at no extra cost to you.
+                          </p>
+                        )}
+                        <a
+                          href={card.href}
+                          target="_blank"
+                          rel={card.monetized ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
+                          className="mt-2 inline-block text-sm font-semibold text-amber-700 hover:underline"
+                        >
+                          {card.cta} →
+                        </a>
+                      </>
                     ) : (
                       <Link href={card.href} className="mt-4 inline-block text-sm font-semibold text-amber-700 hover:underline">
                         {card.cta} →
@@ -305,22 +276,16 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
             </section>
           )}
 
-          {nordPassRecommendedSlugs.has(post.slug) && (
-            <div className="my-6">
-              <NordPassCTA />
-            </div>
-          )}
-
           {bitwardenRecommendedSlugs.has(post.slug) && (
             <blockquote className="bg-indigo-50 border-l-4 border-indigo-300 rounded-r-xl p-4 my-6 text-sm text-indigo-900">
-              <strong>Recommended:</strong> We use and recommend{' '}<a
+              <strong>Free option:</strong>{' '}<a
                 href="https://bitwarden.com/?utm_source=strongpasswordgenerator"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-semibold underline hover:text-indigo-700"
               >
                 Bitwarden
-              </a>{' '}— free, open-source, and trusted by millions.
+              </a>{' '}is an open-source password manager with a free plan.
             </blockquote>
           )}
 
@@ -391,9 +356,14 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
           </Link>
         </div>
 
-        <div className="mt-8">
-          <AffiliateCTA product={affiliateProduct} />
-        </div>
+        {affiliateProduct && (
+          <div className="mt-8">
+            <p className="mb-2 text-xs leading-relaxed text-slate-500">
+              Affiliate disclosure: we may earn a commission if you buy through this link, at no extra cost to you.
+            </p>
+            <AffiliateCTA product={affiliateProduct} />
+          </div>
+        )}
 
         <div className="mt-4 text-center">
           <Link href="/blog" className="text-sm text-indigo-600 hover:underline">

--- a/src/app/editorial-policy/page.tsx
+++ b/src/app/editorial-policy/page.tsx
@@ -40,7 +40,7 @@ export default function EditorialPolicyPage() {
                 "name": "How does StrongPasswordGenerator.dev research articles?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "Security guides are based on vendor documentation, public security guidance, breach-response best practices, and hands-on evaluation where applicable. We prioritize advice that a reader can apply immediately: unique passwords, password managers, two-factor authentication, passkeys, account recovery, and breach monitoring."
+                  "text": "Security guides draw on sources such as vendor documentation and public security guidance. Source links are included in articles when they help readers verify a claim or learn more."
                 }
               },
               {
@@ -48,7 +48,7 @@ export default function EditorialPolicyPage() {
                 "name": "How does StrongPasswordGenerator.dev review recommendations?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "Tool recommendations consider security model, reputation, pricing, ease of use, cross-device support, export options, and fit for the reader's situation. We avoid recommending tools solely because they pay commissions."
+                  "text": "Tool comparisons may consider documented security features, pricing, platform support, export options, and fit for the reader's situation. Articles identify affiliate links where they appear."
                 }
               },
               {
@@ -56,7 +56,7 @@ export default function EditorialPolicyPage() {
                 "name": "How often does StrongPasswordGenerator.dev update content?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "We review commercially important pages more often than evergreen explainers, especially when pricing, feature limits, or vendor positioning changes. When a recommendation meaningfully changes, we update the page rather than quietly redirecting readers to a different product."
+                  "text": "Articles display their publication date. When an article is materially revised, its repository date can be updated to reflect that change."
                 }
               },
               {
@@ -72,7 +72,7 @@ export default function EditorialPolicyPage() {
                 "name": "What kind of content does StrongPasswordGenerator.dev avoid publishing?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "We avoid publishing filler pages, exaggerated scare tactics, fake urgency, or recommendations that exist only to monetize search traffic. If a product is not a good fit for the reader's situation, we would rather point them to a different guide than force a weak recommendation."
+                  "text": "Our editorial standard is to publish practical security guidance in plain language and to distinguish sponsored links from ordinary editorial references."
                 }
               },
               {
@@ -128,25 +128,16 @@ export default function EditorialPolicyPage() {
           <h1 className="text-3xl font-bold text-slate-800 mb-4">Editorial Policy</h1>
           <p className="text-slate-600 leading-relaxed mb-6">
             StrongPasswordGenerator.dev publishes practical password security guidance for everyday users. Our goal is to help readers make safer account-security decisions without hype, fear tactics, or unnecessary complexity.
-          </p>          <section className="bg-blue-50 p-6 rounded-2xl border border-blue-100 mb-6">
-            <h2 className="text-xl font-bold text-slate-800 mb-3">Key Takeaways</h2>
-            <ul className="list-disc list-inside space-y-2 text-slate-700">
-              <li>Our content is based on thorough research, including vendor documentation and security best practices, prioritizing actionable advice for users.</li>
-              <li>Tool recommendations are chosen for their security, reputation, and usability, not solely for affiliate commissions.</li>
-              <li>We frequently review and update content, especially for commercially important pages, to ensure accuracy and relevance.</li>
-              <li>Some links are affiliate links, which may earn us a commission at no extra cost to you, helping to keep our resources free.</li>
-              <li>We avoid scare tactics, fake urgency, or content published solely for monetization, focusing instead on genuine value.</li>
-            </ul>
-          </section>
+          </p>
 
           <section className="bg-blue-50 p-6 rounded-2xl border border-blue-100 mb-6">
             <h2 className="text-xl font-bold text-slate-800 mb-3">Key Takeaways</h2>
             <ul className="list-disc list-inside space-y-2 text-slate-700">
-              <li>Our content is based on thorough research, including vendor documentation and security best practices, prioritizing actionable advice for users.</li>
-              <li>Tool recommendations are chosen for their security, reputation, and usability, not solely for affiliate commissions.</li>
-              <li>We frequently review and update content, especially for commercially important pages, to ensure accuracy and relevance.</li>
-              <li>Some links are affiliate links, which may earn us a commission at no extra cost to you, helping to keep our resources free.</li>
-              <li>We avoid scare tactics, fake urgency, or content published solely for monetization, focusing instead on genuine value.</li>
+              <li>Articles draw on sources such as vendor documentation and public security guidance.</li>
+              <li>Tool comparisons explain the factors considered and identify affiliate links where they appear.</li>
+              <li>Publication dates come from each article&apos;s repository record rather than the site build time.</li>
+              <li>Some links may earn us a commission at no extra cost to the reader.</li>
+              <li>Readers can report factual concerns or broken links through the contact page.</li>
             </ul>
           </section>
 
@@ -154,21 +145,21 @@ export default function EditorialPolicyPage() {
             <section>
               <h2 className="text-xl font-bold text-slate-800 mb-2">How We Research Articles</h2>
               <p>
-                Security guides are based on vendor documentation, public security guidance, breach-response best practices, and hands-on evaluation where applicable. We prioritize advice that a reader can apply immediately: unique passwords, password managers, two-factor authentication, passkeys, account recovery, and breach monitoring.
+                Security guides draw on sources such as vendor documentation and public security guidance. We include source links in articles when they help readers verify a claim or learn more.
               </p>
             </section>
 
             <section>
               <h2 className="text-xl font-bold text-slate-800 mb-2">How We Review Recommendations</h2>
               <p>
-                Tool recommendations consider security model, reputation, pricing, ease of use, cross-device support, export options, and fit for the reader&apos;s situation. We avoid recommending tools solely because they pay commissions.
+                Tool comparisons may consider documented security features, pricing, platform support, export options, and fit for the reader&apos;s situation. Articles identify affiliate links where they appear.
               </p>
             </section>
 
             <section>
               <h2 className="text-xl font-bold text-slate-800 mb-2">How We Update Content</h2>
               <p>
-                We review commercially important pages more often than evergreen explainers, especially when pricing, feature limits, or vendor positioning changes. When a recommendation meaningfully changes, we update the page rather than quietly redirecting readers to a different product.
+                Articles display their publication date. When an article is materially revised, its repository date can be updated to reflect that change.
               </p>
             </section>
 
@@ -182,7 +173,7 @@ export default function EditorialPolicyPage() {
             <section>
               <h2 className="text-xl font-bold text-slate-800 mb-2">What We Avoid</h2>
               <p>
-                We avoid publishing filler pages, exaggerated scare tactics, fake urgency, or recommendations that exist only to monetize search traffic. If a product is not a good fit for the reader&apos;s situation, we would rather point them to a different guide than force a weak recommendation.
+                Our editorial standard is to publish practical security guidance in plain language and to distinguish sponsored links from ordinary editorial references.
               </p>
             </section>
 
@@ -199,15 +190,15 @@ export default function EditorialPolicyPage() {
             <div className="space-y-6">
               <div>
                 <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: How does StrongPasswordGenerator.dev research articles?</h3>
-                <p className="text-slate-600 leading-relaxed">A: Security guides are based on vendor documentation, public security guidance, breach-response best practices, and hands-on evaluation where applicable. We prioritize advice that a reader can apply immediately: unique passwords, password managers, two-factor authentication, passkeys, account recovery, and breach monitoring.</p>
+                <p className="text-slate-600 leading-relaxed">A: Security guides draw on sources such as vendor documentation and public security guidance. Source links are included when they help readers verify a claim or learn more.</p>
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: How does StrongPasswordGenerator.dev review recommendations?</h3>
-                <p className="text-slate-600 leading-relaxed">A: Tool recommendations consider security model, reputation, pricing, ease of use, cross-device support, export options, and fit for the reader&apos;s situation. We avoid recommending tools solely because they pay commissions.</p>
+                <p className="text-slate-600 leading-relaxed">A: Tool comparisons may consider documented security features, pricing, platform support, export options, and fit for the reader&apos;s situation. Articles identify affiliate links where they appear.</p>
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: How often does StrongPasswordGenerator.dev update content?</h3>
-                <p className="text-slate-600 leading-relaxed">A: We review commercially important pages more often than evergreen explainers, especially when pricing, feature limits, or vendor positioning changes. When a recommendation meaningfully changes, we update the page rather than quietly redirecting readers to a different product.</p>
+                <p className="text-slate-600 leading-relaxed">A: Articles display their publication date. When an article is materially revised, its repository date can be updated to reflect that change.</p>
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: Does StrongPasswordGenerator.dev use affiliate links?</h3>
@@ -215,7 +206,7 @@ export default function EditorialPolicyPage() {
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: What kind of content does StrongPasswordGenerator.dev avoid publishing?</h3>
-                <p className="text-slate-600 leading-relaxed">A: We avoid publishing filler pages, exaggerated scare tactics, fake urgency, or recommendations that exist only to monetize search traffic. If a product is not a good fit for the reader&apos;s situation, we would rather point them to a different guide than force a weak recommendation.</p>
+                <p className="text-slate-600 leading-relaxed">A: Our editorial standard is to publish practical security guidance in plain language and to distinguish sponsored links from ordinary editorial references.</p>
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-slate-800 mb-1">Q: How can I report corrections or updates to StrongPasswordGenerator.dev?</h3>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,73 +6,61 @@ const BASE_URL = 'https://strongpasswordgenerator.dev';
 const staticRoutes: MetadataRoute.Sitemap = [
   {
     url: BASE_URL,
-    lastModified: new Date(),
     changeFrequency: 'weekly',
     priority: 1.0,
   },
   {
     url: `${BASE_URL}/blog`,
-    lastModified: new Date(),
     changeFrequency: 'weekly',
     priority: 0.9,
   },
   {
     url: `${BASE_URL}/recommended-tools`,
-    lastModified: new Date(),
     changeFrequency: 'weekly',
     priority: 0.9,
   },
   {
     url: `${BASE_URL}/password-safety-checklist`,
-    lastModified: new Date(),
     changeFrequency: 'monthly',
     priority: 0.85,
   },
   {
     url: `${BASE_URL}/blog/password-managers`,
-    lastModified: new Date(),
     changeFrequency: 'monthly',
     priority: 0.8,
   },
   {
     url: `${BASE_URL}/blog/password-security`,
-    lastModified: new Date(),
     changeFrequency: 'monthly',
     priority: 0.8,
   },
   {
     url: `${BASE_URL}/blog/phishing`,
-    lastModified: new Date(),
     changeFrequency: 'monthly',
     priority: 0.8,
   },
   {
     url: `${BASE_URL}/about`,
-    lastModified: new Date(),
     changeFrequency: 'weekly',
     priority: 0.5,
   },
   {
     url: `${BASE_URL}/contact`,
-    lastModified: new Date(),
     changeFrequency: 'weekly',
     priority: 0.5,
   },
   {
     url: `${BASE_URL}/privacy`,
-    lastModified: new Date(),
     changeFrequency: 'weekly',
     priority: 0.5,
   },
   {
     url: `${BASE_URL}/terms`,
-    lastModified: new Date(),
     changeFrequency: 'weekly',
     priority: 0.5,
   },
   {
     url: `${BASE_URL}/editorial-policy`,
-    lastModified: new Date(),
     changeFrequency: 'monthly',
     priority: 0.5,
   },


### PR DESCRIPTION
## What changed

- limits article affiliate CTAs to explicit commercial-intent slug allowlists
- adds adjacent disclosures before every remaining monetized article link
- keeps Bitwarden references editorial and unsponsored
- changes article authorship schema from a fictitious person to the site organization
- removes duplicate breadcrumb schema and duplicate editorial-policy content
- replaces unsupported editorial-process claims with verifiable language
- stops assigning build-time `lastModified` dates to unchanged static sitemap URLs

## Why

The article template previously attached a commercial CTA to every post and represented the brand as a person. Static sitemap pages also appeared freshly modified on every deployment. These signals made informational content look monetization-led and weakened trust.

## Validation

- `npm test` — 6/6 passed
- `npm run build` — 94/94 static pages generated
- `npm run lint` — passed
- `npm run check:adsense` — passed local readiness checks
- `git diff --check`

Closes #437
