### PR TITLE
research: classify every SPG URL before consolidation

### DIFF
--- a/docs/URL_DECISION_MANIFEST.json
+++ b/docs/URL_DECISION_MANIFEST.json
@@ -1,0 +1,1740 @@
+{
+  "schemaVersion": 1,
+  "site": "https://strongpasswordgenerator.dev",
+  "notice": "Proposed classifications only. Production mutation requires a separate approved issue.",
+  "inventory": {
+    "staticSitemapRoutes": 12,
+    "articleRecords": 78,
+    "articleFiles": 78,
+    "totalUrls": 90
+  },
+  "decisionCounts": {
+    "keep": 12,
+    "rewrite": 30,
+    "consolidate-to": 28,
+    "remove": 20
+  },
+  "editorialShortlist": [
+    "/blog/best-password-manager-for-business-2026",
+    "/blog/best-password-manager-for-families-2026",
+    "/blog/best-password-manager-iphone-ios-2026",
+    "/blog/bitwarden-setup-guide",
+    "/blog/bitwarden-vs-1password-2026",
+    "/blog/browser-security-settings",
+    "/blog/credential-stuffing-explained",
+    "/blog/data-breach-what-to-do",
+    "/blog/free-vs-paid-password-managers-2026",
+    "/blog/google-password-manager-review",
+    "/blog/how-to-create-strong-password",
+    "/blog/how-to-share-passwords-safely",
+    "/blog/how-to-spot-fake-websites",
+    "/blog/lastpass-alternatives",
+    "/blog/nordpass-review-2026",
+    "/blog/nordpass-vs-dashlane-2026",
+    "/blog/passkeys-explained",
+    "/blog/passkeys-vs-passwords-2026",
+    "/blog/password-hygiene-for-families",
+    "/blog/password-manager-vs-browser-autofill",
+    "/blog/password-reuse-risks",
+    "/blog/password-security-for-remote-workers",
+    "/blog/password-security-for-seniors",
+    "/blog/public-wifi-security-tips",
+    "/blog/securing-apple-id",
+    "/blog/securing-online-banking",
+    "/blog/securing-social-media-accounts",
+    "/blog/securing-your-email-account",
+    "/blog/two-factor-authentication-guide",
+    "/blog/what-is-phishing-and-how-to-avoid-it"
+  ],
+  "consolidationClusters": [
+    {
+      "name": "business password managers",
+      "destination": "/blog/best-password-manager-for-business-2026",
+      "sources": [
+        "/blog/password-manager-for-business"
+      ]
+    },
+    {
+      "name": "authenticators and 2FA",
+      "destination": "/blog/two-factor-authentication-guide",
+      "sources": [
+        "/blog/google-authenticator-vs-authy",
+        "/blog/mfa-fatigue-attack-explained",
+        "/blog/microsoft-authenticator-guide",
+        "/blog/sim-swapping-protection",
+        "/blog/yubikey-setup-guide"
+      ]
+    },
+    {
+      "name": "breach and identity response",
+      "destination": "/blog/data-breach-what-to-do",
+      "sources": [
+        "/blog/dark-web-monitoring-explained",
+        "/blog/data-broker-opt-out-guide",
+        "/blog/how-to-check-if-youve-been-hacked",
+        "/blog/how-to-freeze-your-credit",
+        "/blog/how-to-recover-from-identity-theft",
+        "/blog/identity-theft-protection-guide",
+        "/blog/identity-theft-statistics-2026"
+      ]
+    },
+    {
+      "name": "VPN and public Wi-Fi",
+      "destination": "/blog/public-wifi-security-tips",
+      "sources": [
+        "/blog/how-to-use-a-vpn-for-privacy",
+        "/blog/vpn-for-remote-work",
+        "/blog/wifi-password-best-practices"
+      ]
+    },
+    {
+      "name": "account-specific security",
+      "destination": "multiple retained account guides",
+      "sources": [
+        "/blog/email-security-best-practices-2026",
+        "/blog/microsoft-account-security-guide",
+        "/blog/securing-facebook-account",
+        "/blog/securing-google-account",
+        "/blog/securing-linkedin-account",
+        "/blog/securing-venmo-cashapp-paypal"
+      ]
+    },
+    {
+      "name": "network and browser security",
+      "destination": "/blog/browser-security-settings",
+      "sources": [
+        "/blog/securing-home-network"
+      ]
+    }
+  ],
+  "stopLoss": {
+    "day30": {
+      "search": "At least 50 organic impressions across retained editorial URLs.",
+      "affiliate": "At least 3 tracked outbound affiliate clicks."
+    },
+    "day60": {
+      "search": "At least 150 organic impressions and 2 organic clicks across retained editorial URLs.",
+      "affiliate": "At least 10 tracked outbound affiliate clicks."
+    },
+    "day90": {
+      "search": "At least 300 organic impressions and 5 organic clicks across retained editorial URLs.",
+      "affiliate": "At least 20 tracked outbound affiliate clicks or 1 attributed conversion."
+    },
+    "action": "If a checkpoint misses both thresholds, stop publishing, diagnose indexing and intent fit, and consolidate or exit the underperforming cluster before investing further."
+  },
+  "urls": [
+    {
+      "url": "/",
+      "routeKind": "utility",
+      "title": "Strong Password Generator",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/about",
+      "routeKind": "trust",
+      "title": "About",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/blog",
+      "routeKind": "hub",
+      "title": "Blog",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/blog/ai-voice-cloning-scams",
+      "routeKind": "article",
+      "title": "AI Voice Cloning Scams: How to Protect Yourself and Your Family",
+      "date": "2026-07-17",
+      "category": "Best Practices",
+      "wordCount": 1363,
+      "internalLinks": 6,
+      "credibleSources": 0,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/android-password-tips",
+      "routeKind": "article",
+      "title": "Android Password Security Tips: How to Lock Down Your Phone and Accounts",
+      "date": "2026-05-17",
+      "category": "Best Practices",
+      "wordCount": 1522,
+      "internalLinks": 3,
+      "credibleSources": 3,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/how-to-create-strong-password",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/antivirus-software-guide",
+      "routeKind": "article",
+      "title": "Antivirus Software Guide 2026: Do You Need It, Which to Choose, and How to Configure It",
+      "date": "2026-06-16",
+      "category": "Best Practices",
+      "wordCount": 1413,
+      "internalLinks": 3,
+      "credibleSources": 5,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/best-antivirus-software-2026",
+      "routeKind": "article",
+      "title": "Best Antivirus Software of 2026: How to Choose the Right Protection",
+      "date": "2026-05-24",
+      "category": "Best Practices",
+      "wordCount": 1473,
+      "internalLinks": 2,
+      "credibleSources": 5,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/best-identity-theft-protection-2026",
+      "routeKind": "article",
+      "title": "Best Identity Theft Protection Services (2026): Compared and Reviewed",
+      "date": "2026-06-12",
+      "category": "Best Practices",
+      "wordCount": 1232,
+      "internalLinks": 5,
+      "credibleSources": 0,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Remove because no retained URL is a genuinely equivalent redirect destination."
+    },
+    {
+      "url": "/blog/best-password-manager-for-business-2026",
+      "routeKind": "article",
+      "title": "Best Password Manager for Small Business and Teams (2026)",
+      "date": "2026-06-12",
+      "category": "Password Managers",
+      "wordCount": 1296,
+      "internalLinks": 6,
+      "credibleSources": 3,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/best-password-manager-for-families-2026",
+      "routeKind": "article",
+      "title": "Best Password Manager for Families in 2026: Shared Vaults, Emergency Access, and Kid-Safe Setup",
+      "date": "2026-07-03",
+      "category": "Password Managers",
+      "wordCount": 1220,
+      "internalLinks": 6,
+      "credibleSources": 4,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/best-password-manager-iphone-ios-2026",
+      "routeKind": "article",
+      "title": "Best Password Manager for iPhone and iOS (2026): Top 5 Compared",
+      "date": "2026-06-16",
+      "category": "Password Managers",
+      "wordCount": 1217,
+      "internalLinks": 5,
+      "credibleSources": 3,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/bitwarden-setup-guide",
+      "routeKind": "article",
+      "title": "Bitwarden Setup Guide: How to Get Started with the Best Free Password Manager",
+      "date": "2026-04-15",
+      "category": "Password Managers",
+      "wordCount": 1616,
+      "internalLinks": 2,
+      "credibleSources": 2,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/bitwarden-vs-1password-2026",
+      "routeKind": "article",
+      "title": "Bitwarden vs 1Password (2026): Which Password Manager Should You Use?",
+      "date": "2026-06-10",
+      "category": "Password Managers",
+      "wordCount": 1310,
+      "internalLinks": 5,
+      "credibleSources": 6,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/browser-security-settings",
+      "routeKind": "article",
+      "title": "Browser Security Settings: The Complete Hardening Guide for Chrome, Firefox, and Safari",
+      "date": "2026-05-21",
+      "category": "Best Practices",
+      "wordCount": 1297,
+      "internalLinks": 5,
+      "credibleSources": 1,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/credential-stuffing-explained",
+      "routeKind": "article",
+      "title": "Credential Stuffing Explained: What It Is and How to Stop It",
+      "date": "2026-06-23",
+      "category": "Password Security",
+      "wordCount": 1534,
+      "internalLinks": 6,
+      "credibleSources": 1,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/dark-web-monitoring-explained",
+      "routeKind": "article",
+      "title": "Dark Web Monitoring Explained: What It Is, How It Works, and Do You Need It?",
+      "date": "2026-05-27",
+      "category": "Best Practices",
+      "wordCount": 1362,
+      "internalLinks": 3,
+      "credibleSources": 0,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/data-breach-what-to-do",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/data-breach-what-to-do",
+      "routeKind": "article",
+      "title": "Data Breach: What to Do Immediately if Your Information Is Exposed",
+      "date": "2026-05-17",
+      "category": "Data Breaches",
+      "wordCount": 1765,
+      "internalLinks": 3,
+      "credibleSources": 4,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/data-broker-opt-out-guide",
+      "routeKind": "article",
+      "title": "How to Remove Your Personal Information From Data Broker Sites",
+      "date": "2026-07-16",
+      "category": "Data Breaches",
+      "wordCount": 1447,
+      "internalLinks": 4,
+      "credibleSources": 0,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/data-breach-what-to-do",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/email-security-best-practices-2026",
+      "routeKind": "article",
+      "title": "Email Security Best Practices 2026: Protect Your Inbox from Hackers and Phishing",
+      "date": "2026-06-20",
+      "category": "Best Practices",
+      "wordCount": 1677,
+      "internalLinks": 5,
+      "credibleSources": 2,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/securing-your-email-account",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/encrypted-messaging-apps-guide",
+      "routeKind": "article",
+      "title": "Encrypted Messaging Apps Compared: Signal vs. WhatsApp vs. iMessage vs. Telegram",
+      "date": "2026-07-02",
+      "category": "Best Practices",
+      "wordCount": 1023,
+      "internalLinks": 4,
+      "credibleSources": 0,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/free-vs-paid-password-managers-2026",
+      "routeKind": "article",
+      "title": "Free vs Paid Password Managers in 2026: What You Actually Get for Your Money",
+      "date": "2026-06-19",
+      "category": "Password Managers",
+      "wordCount": 1364,
+      "internalLinks": 5,
+      "credibleSources": 3,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/github-security-best-practices",
+      "routeKind": "article",
+      "title": "GitHub Security Best Practices: Protect Your Code and Account",
+      "date": "2026-04-28",
+      "category": "Best Practices",
+      "wordCount": 1869,
+      "internalLinks": 6,
+      "credibleSources": 2,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/google-authenticator-vs-authy",
+      "routeKind": "article",
+      "title": "Google Authenticator vs. Authy: Which 2FA App Should You Use in 2026?",
+      "date": "2026-06-21",
+      "category": "2FA",
+      "wordCount": 1473,
+      "internalLinks": 5,
+      "credibleSources": 3,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/two-factor-authentication-guide",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/google-password-manager-review",
+      "routeKind": "article",
+      "title": "Google Password Manager Review 2026: Is It Good Enough for Your Security?",
+      "date": "2026-04-28",
+      "category": "Password Managers",
+      "wordCount": 1660,
+      "internalLinks": 6,
+      "credibleSources": 4,
+      "affiliateLinks": 7,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/how-to-check-if-youve-been-hacked",
+      "routeKind": "article",
+      "title": "How to Check If You've Been Hacked: Warning Signs and What to Do Next",
+      "date": "2026-06-17",
+      "category": "Best Practices",
+      "wordCount": 1653,
+      "internalLinks": 10,
+      "credibleSources": 0,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/data-breach-what-to-do",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/how-to-create-strong-password",
+      "routeKind": "article",
+      "title": "How to Create a Strong Password: The Complete Guide for 2026",
+      "date": "2026-06-18",
+      "category": "Password Security",
+      "wordCount": 1421,
+      "internalLinks": 7,
+      "credibleSources": 2,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/how-to-freeze-your-credit",
+      "routeKind": "article",
+      "title": "How to Freeze Your Credit: The Complete Step-by-Step Guide",
+      "date": "2026-05-28",
+      "category": "Best Practices",
+      "wordCount": 2079,
+      "internalLinks": 5,
+      "credibleSources": 0,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/data-breach-what-to-do",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/how-to-recover-from-identity-theft",
+      "routeKind": "article",
+      "title": "How to Recover from Identity Theft: A Complete Step-by-Step Action Plan",
+      "date": "2026-06-22",
+      "category": "Data Breaches",
+      "wordCount": 1877,
+      "internalLinks": 8,
+      "credibleSources": 4,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/data-breach-what-to-do",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/how-to-share-passwords-safely",
+      "routeKind": "article",
+      "title": "How to Share Passwords Safely (Without Texting or Emailing Them)",
+      "date": "2026-07-16",
+      "category": "Password Managers",
+      "wordCount": 1380,
+      "internalLinks": 10,
+      "credibleSources": 1,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/how-to-spot-fake-websites",
+      "routeKind": "article",
+      "title": "How to Spot Fake Websites: A Practical Guide to Avoiding Phishing and Scam Sites",
+      "date": "2026-05-25",
+      "category": "Best Practices",
+      "wordCount": 1462,
+      "internalLinks": 2,
+      "credibleSources": 2,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/how-to-use-a-vpn-for-privacy",
+      "routeKind": "article",
+      "title": "How to Use a VPN for Privacy: A Practical Guide (2026)",
+      "date": "2026-06-12",
+      "category": "Best Practices",
+      "wordCount": 1833,
+      "internalLinks": 8,
+      "credibleSources": 0,
+      "affiliateLinks": 7,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/public-wifi-security-tips",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/identity-theft-protection-guide",
+      "routeKind": "article",
+      "title": "Identity Theft Protection Guide: How to Secure Your Personal Data in 2026",
+      "date": "2026-05-23",
+      "category": "Best Practices",
+      "wordCount": 1473,
+      "internalLinks": 4,
+      "credibleSources": 4,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "consolidate-to",
+      "destination": "/blog/data-breach-what-to-do",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/identity-theft-statistics-2026",
+      "routeKind": "article",
+      "title": "Identity Theft Statistics 2026: What the Data Actually Shows",
+      "date": "2026-06-02",
+      "category": "Data Breaches",
+      "wordCount": 1891,
+      "internalLinks": 6,
+      "credibleSources": 2,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/data-breach-what-to-do",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/iphone-password-security",
+      "routeKind": "article",
+      "title": "Complete iPhone Password Security Guide: Protecting Your Apple ID & Accounts",
+      "date": "2026-04-30",
+      "category": "Best Practices",
+      "wordCount": 2018,
+      "internalLinks": 3,
+      "credibleSources": 3,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/securing-apple-id",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/lastpass-alternatives",
+      "routeKind": "article",
+      "title": "The Best LastPass Alternatives in 2026: Safer, Cheaper, Better Options",
+      "date": "2026-05-05",
+      "category": "Password Managers",
+      "wordCount": 1247,
+      "internalLinks": 6,
+      "credibleSources": 2,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/mfa-fatigue-attack-explained",
+      "routeKind": "article",
+      "title": "MFA Fatigue Attacks: How Push Notification Abuse Bypasses Two-Factor Authentication",
+      "date": "2026-06-23",
+      "category": "2FA",
+      "wordCount": 1505,
+      "internalLinks": 7,
+      "credibleSources": 0,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/two-factor-authentication-guide",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/microsoft-account-security-guide",
+      "routeKind": "article",
+      "title": "How to Secure Your Microsoft Account: Passwords, 2FA, and Recovery Options",
+      "date": "2026-06-19",
+      "category": "Best Practices",
+      "wordCount": 1534,
+      "internalLinks": 6,
+      "credibleSources": 2,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/securing-your-email-account",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/microsoft-authenticator-guide",
+      "routeKind": "article",
+      "title": "Microsoft Authenticator Guide: Set Up Strong 2FA on Every Account",
+      "date": "2026-05-12",
+      "category": "2FA",
+      "wordCount": 1924,
+      "internalLinks": 4,
+      "credibleSources": 2,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/two-factor-authentication-guide",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/nordpass-review-2026",
+      "routeKind": "article",
+      "title": "NordPass Review 2026: Is This Password Manager Worth It?",
+      "date": "2026-06-29",
+      "category": "Password Managers",
+      "wordCount": 1461,
+      "internalLinks": 10,
+      "credibleSources": 1,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/nordpass-vs-dashlane-2026",
+      "routeKind": "article",
+      "title": "NordPass vs Dashlane (2026): Which Password Manager Is Better?",
+      "date": "2026-06-11",
+      "category": "Password Managers",
+      "wordCount": 1458,
+      "internalLinks": 8,
+      "credibleSources": 1,
+      "affiliateLinks": 7,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/nordprotect-review-2026",
+      "routeKind": "article",
+      "title": "NordProtect Review 2026: Is This Identity Protection Service Worth It?",
+      "date": "2026-06-11",
+      "category": "Data Breaches",
+      "wordCount": 1758,
+      "internalLinks": 4,
+      "credibleSources": 0,
+      "affiliateLinks": 11,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Remove because no retained URL is a genuinely equivalent redirect destination."
+    },
+    {
+      "url": "/blog/nordvpn-review-2026",
+      "routeKind": "article",
+      "title": "NordVPN Review 2026: Is It Still the Best VPN for Privacy and Security?",
+      "date": "2026-06-14",
+      "category": "Password Security",
+      "wordCount": 1245,
+      "internalLinks": 6,
+      "credibleSources": 1,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Remove because no retained URL is a genuinely equivalent redirect destination."
+    },
+    {
+      "url": "/blog/nordvpn-vs-expressvpn",
+      "routeKind": "article",
+      "title": "NordVPN vs ExpressVPN (2026): Which VPN Is Worth Your Money?",
+      "date": "2026-06-15",
+      "category": "Best Practices",
+      "wordCount": 1537,
+      "internalLinks": 4,
+      "credibleSources": 1,
+      "affiliateLinks": 7,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Remove because no retained URL is a genuinely equivalent redirect destination."
+    },
+    {
+      "url": "/blog/passkeys-explained",
+      "routeKind": "article",
+      "title": "Passkeys Explained: The Future of Passwordless Login and How to Use Them",
+      "date": "2026-05-17",
+      "category": "Best Practices",
+      "wordCount": 2024,
+      "internalLinks": 6,
+      "credibleSources": 5,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/passkeys-vs-passwords-2026",
+      "routeKind": "article",
+      "title": "Are Passkeys Replacing Passwords in 2026? The Complete Guide",
+      "date": "2026-06-14",
+      "category": "Security Trends",
+      "wordCount": 1804,
+      "internalLinks": 6,
+      "credibleSources": 5,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/password-hygiene-for-families",
+      "routeKind": "article",
+      "title": "Password Hygiene for Families: How to Keep Every Household Account Secure",
+      "date": "2026-05-08",
+      "category": "Best Practices",
+      "wordCount": 2438,
+      "internalLinks": 6,
+      "credibleSources": 4,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/password-manager-for-business",
+      "routeKind": "article",
+      "title": "Password Manager for Business: How to Secure Your Team's Credentials in 2026",
+      "date": "2026-06-17",
+      "category": "Password Managers",
+      "wordCount": 1483,
+      "internalLinks": 4,
+      "credibleSources": 2,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/best-password-manager-for-business-2026",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/password-manager-for-college-students",
+      "routeKind": "article",
+      "title": "Best Password Manager Setup for College Students (Free Options Included)",
+      "date": "2026-07-17",
+      "category": "Password Managers",
+      "wordCount": 1306,
+      "internalLinks": 8,
+      "credibleSources": 0,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/free-vs-paid-password-managers-2026",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/password-manager-vs-browser-autofill",
+      "routeKind": "article",
+      "title": "Password Manager vs. Browser Autofill: Which Is Actually More Secure?",
+      "date": "2026-06-18",
+      "category": "Password Managers",
+      "wordCount": 1338,
+      "internalLinks": 4,
+      "credibleSources": 3,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/password-managers",
+      "routeKind": "hub",
+      "title": "Blog/Password Managers",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/blog/password-reuse-risks",
+      "routeKind": "article",
+      "title": "The Dangers of Password Reuse: Why Using the Same Password Everywhere Is a Security Disaster",
+      "date": "2026-06-22",
+      "category": "Password Security",
+      "wordCount": 1869,
+      "internalLinks": 8,
+      "credibleSources": 3,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/password-security",
+      "routeKind": "hub",
+      "title": "Blog/Password Security",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/blog/password-security-audit-checklist",
+      "routeKind": "article",
+      "title": "Password Security Audit Checklist: 20 Steps to Harden Every Account You Own",
+      "date": "2026-05-12",
+      "category": "Best Practices",
+      "wordCount": 1582,
+      "internalLinks": 6,
+      "credibleSources": 3,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/how-to-create-strong-password",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/password-security-for-remote-workers",
+      "routeKind": "article",
+      "title": "Password Security for Remote Workers: How to Stay Safe Outside the Office",
+      "date": "2026-04-16",
+      "category": "Best Practices",
+      "wordCount": 2064,
+      "internalLinks": 2,
+      "credibleSources": 2,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/password-security-for-seniors",
+      "routeKind": "article",
+      "title": "Password Security for Seniors: A Simple, Step-by-Step Guide",
+      "date": "2026-05-05",
+      "category": "Best Practices",
+      "wordCount": 2472,
+      "internalLinks": 6,
+      "credibleSources": 0,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/phishing",
+      "routeKind": "hub",
+      "title": "Blog/Phishing",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/blog/protecting-kids-online",
+      "routeKind": "article",
+      "title": "Protecting Kids Online: A Parent's Complete Guide to Account Security",
+      "date": "2026-05-25",
+      "category": "Best Practices",
+      "wordCount": 1620,
+      "internalLinks": 4,
+      "credibleSources": 4,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/public-wifi-security-tips",
+      "routeKind": "article",
+      "title": "Public Wi-Fi Security: How to Stay Safe on Unsecured Networks",
+      "date": "2026-06-29",
+      "category": "Best Practices",
+      "wordCount": 1520,
+      "internalLinks": 6,
+      "credibleSources": 0,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/qr-code-scam-quishing-guide",
+      "routeKind": "article",
+      "title": "QR Code Scams (\"Quishing\"): How They Work and How to Spot One",
+      "date": "2026-07-19",
+      "category": "Best Practices",
+      "wordCount": 1003,
+      "internalLinks": 3,
+      "credibleSources": 0,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/what-is-phishing-and-how-to-avoid-it",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/securing-apple-id",
+      "routeKind": "article",
+      "title": "How to Secure Your Apple ID: The Complete Protection Guide",
+      "date": "2026-05-18",
+      "category": "Best Practices",
+      "wordCount": 1857,
+      "internalLinks": 4,
+      "credibleSources": 2,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/securing-cloud-storage",
+      "routeKind": "article",
+      "title": "How to Secure Your Cloud Storage: Google Drive, iCloud, Dropbox, and OneDrive",
+      "date": "2026-06-15",
+      "category": "Best Practices",
+      "wordCount": 1295,
+      "internalLinks": 5,
+      "credibleSources": 4,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/securing-crypto-wallets",
+      "routeKind": "article",
+      "title": "How to Secure Your Crypto Wallet: Passwords, Seed Phrases, and Account Protection",
+      "date": "2026-05-17",
+      "category": "Best Practices",
+      "wordCount": 1827,
+      "internalLinks": 7,
+      "credibleSources": 2,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/securing-facebook-account",
+      "routeKind": "article",
+      "title": "How to Secure Your Facebook Account: The Complete 2026 Guide",
+      "date": "2026-06-21",
+      "category": "Best Practices",
+      "wordCount": 1534,
+      "internalLinks": 5,
+      "credibleSources": 1,
+      "affiliateLinks": 8,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/securing-social-media-accounts",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/securing-google-account",
+      "routeKind": "article",
+      "title": "How to Secure Your Google Account: A Complete Checklist",
+      "date": "2026-07-19",
+      "category": "Best Practices",
+      "wordCount": 1008,
+      "internalLinks": 6,
+      "credibleSources": 0,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/securing-your-email-account",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/securing-home-network",
+      "routeKind": "article",
+      "title": "How to Secure Your Home Network: A Step-by-Step Guide to Router and Wi-Fi Security",
+      "date": "2026-05-17",
+      "category": "Best Practices",
+      "wordCount": 1568,
+      "internalLinks": 3,
+      "credibleSources": 2,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/browser-security-settings",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/securing-linkedin-account",
+      "routeKind": "article",
+      "title": "How to Secure Your LinkedIn Account: Passwords, 2FA, and Privacy Settings",
+      "date": "2026-05-23",
+      "category": "Best Practices",
+      "wordCount": 1665,
+      "internalLinks": 6,
+      "credibleSources": 3,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/securing-social-media-accounts",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/securing-online-banking",
+      "routeKind": "article",
+      "title": "Secure Online Banking: How to Protect Your Bank Account from Hacking",
+      "date": "2026-04-30",
+      "category": "Best Practices",
+      "wordCount": 1500,
+      "internalLinks": 9,
+      "credibleSources": 2,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/securing-remote-desktop-rdp",
+      "routeKind": "article",
+      "title": "How to Secure Remote Desktop Access: RDP, VPNs, and Remote Work Security in 2026",
+      "date": "2026-06-20",
+      "category": "Best Practices",
+      "wordCount": 1734,
+      "internalLinks": 6,
+      "credibleSources": 3,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/securing-smart-home-devices",
+      "routeKind": "article",
+      "title": "How to Secure Your Smart Home Devices in 2026",
+      "date": "2026-06-11",
+      "category": "Best Practices",
+      "wordCount": 1333,
+      "internalLinks": 4,
+      "credibleSources": 1,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/securing-social-media-accounts",
+      "routeKind": "article",
+      "title": "How to Secure Your Social Media Accounts: A Practical Guide",
+      "date": "2026-04-16",
+      "category": "Best Practices",
+      "wordCount": 1963,
+      "internalLinks": 3,
+      "credibleSources": 2,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/securing-venmo-cashapp-paypal",
+      "routeKind": "article",
+      "title": "How to Secure Your Venmo, Cash App, and PayPal Accounts",
+      "date": "2026-07-02",
+      "category": "Best Practices",
+      "wordCount": 1258,
+      "internalLinks": 8,
+      "credibleSources": 1,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/securing-online-banking",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/securing-your-amazon-account",
+      "routeKind": "article",
+      "title": "How to Secure Your Amazon Account: A Complete Security Guide",
+      "date": "2026-05-22",
+      "category": "Best Practices",
+      "wordCount": 1691,
+      "internalLinks": 9,
+      "credibleSources": 2,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Remove because no retained URL is a genuinely equivalent redirect destination."
+    },
+    {
+      "url": "/blog/securing-your-email-account",
+      "routeKind": "article",
+      "title": "How to Secure Your Email Account: The Complete Guide",
+      "date": "2026-04-15",
+      "category": "Best Practices",
+      "wordCount": 1752,
+      "internalLinks": 3,
+      "credibleSources": 4,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/sim-swapping-protection",
+      "routeKind": "article",
+      "title": "SIM Swapping Protection: How to Stop Attackers From Hijacking Your Phone Number",
+      "date": "2026-05-22",
+      "category": "Best Practices",
+      "wordCount": 1691,
+      "internalLinks": 6,
+      "credibleSources": 2,
+      "affiliateLinks": 7,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/two-factor-authentication-guide",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/two-factor-authentication-guide",
+      "routeKind": "article",
+      "title": "Two-Factor Authentication Guide: How to Enable 2FA on Every Important Account",
+      "date": "2026-05-17",
+      "category": "2FA",
+      "wordCount": 1339,
+      "internalLinks": 7,
+      "credibleSources": 3,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/vpn-for-remote-work",
+      "routeKind": "article",
+      "title": "VPN for Remote Work: How to Stay Secure Working Outside the Office",
+      "date": "2026-05-18",
+      "category": "Best Practices",
+      "wordCount": 1921,
+      "internalLinks": 6,
+      "credibleSources": 2,
+      "affiliateLinks": 8,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/public-wifi-security-tips",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/vpn-vs-password-manager",
+      "routeKind": "article",
+      "title": "VPN vs Password Manager: Do You Need Both?",
+      "date": "2026-06-11",
+      "category": "Best Practices",
+      "wordCount": 1180,
+      "internalLinks": 6,
+      "credibleSources": 3,
+      "affiliateLinks": 8,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Remove because no retained URL is a genuinely equivalent redirect destination."
+    },
+    {
+      "url": "/blog/vpn-worth-it-2026",
+      "routeKind": "article",
+      "title": "Is a VPN Worth It in 2026? An Honest Look at What VPNs Do and Don't Protect",
+      "date": "2026-06-11",
+      "category": "Best Practices",
+      "wordCount": 1839,
+      "internalLinks": 6,
+      "credibleSources": 0,
+      "affiliateLinks": 7,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Remove because no retained URL is a genuinely equivalent redirect destination."
+    },
+    {
+      "url": "/blog/what-is-nordprotect",
+      "routeKind": "article",
+      "title": "What Is NordProtect? Identity Theft Protection Explained",
+      "date": "2026-06-14",
+      "category": "Password Security",
+      "wordCount": 1252,
+      "internalLinks": 6,
+      "credibleSources": 0,
+      "affiliateLinks": 7,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "no-credible-external-sources"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Remove because no retained URL is a genuinely equivalent redirect destination."
+    },
+    {
+      "url": "/blog/what-is-phishing-and-how-to-avoid-it",
+      "routeKind": "article",
+      "title": "What Is Phishing and How to Avoid It: A Practical Guide",
+      "date": "2026-04-21",
+      "category": "Best Practices",
+      "wordCount": 2177,
+      "internalLinks": 6,
+      "credibleSources": 3,
+      "affiliateLinks": 5,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "rewrite",
+      "destination": null,
+      "rationale": "Reviewed editorial shortlist aligned to core user intent."
+    },
+    {
+      "url": "/blog/wifi-password-best-practices",
+      "routeKind": "article",
+      "title": "Wi-Fi Password Best Practices: How to Secure Your Home and Office Network",
+      "date": "2026-04-21",
+      "category": "Best Practices",
+      "wordCount": 1885,
+      "internalLinks": 1,
+      "credibleSources": 3,
+      "affiliateLinks": 4,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "few-internal-links"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/public-wifi-security-tips",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/wordpress-security-passwords",
+      "routeKind": "article",
+      "title": "WordPress Security: How to Lock Down Passwords, Logins, and Admin Access",
+      "date": "2026-06-16",
+      "category": "Best Practices",
+      "wordCount": 1561,
+      "internalLinks": 4,
+      "credibleSources": 2,
+      "affiliateLinks": 3,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/blog/yubikey-setup-guide",
+      "routeKind": "article",
+      "title": "YubiKey Setup Guide: How to Use a Hardware Security Key for Maximum Protection",
+      "date": "2026-05-08",
+      "category": "2FA",
+      "wordCount": 1752,
+      "internalLinks": 2,
+      "credibleSources": 2,
+      "affiliateLinks": 2,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description"
+      ],
+      "decision": "consolidate-to",
+      "destination": "/blog/two-factor-authentication-guide",
+      "rationale": "Overlapping intent belongs in a stronger retained destination."
+    },
+    {
+      "url": "/blog/zero-trust-security-basics",
+      "routeKind": "article",
+      "title": "Zero Trust Security Explained: A Practical Guide for Individuals and Small Businesses",
+      "date": "2026-05-24",
+      "category": "Best Practices",
+      "wordCount": 1749,
+      "internalLinks": 8,
+      "credibleSources": 3,
+      "affiliateLinks": 6,
+      "sitemapPresent": true,
+      "qualityFlags": [
+        "missing-description",
+        "off-topic-reviewed-removal"
+      ],
+      "decision": "remove",
+      "destination": null,
+      "rationale": "Explicitly reviewed as off-topic for a focused password-generation site."
+    },
+    {
+      "url": "/contact",
+      "routeKind": "trust",
+      "title": "Contact",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/editorial-policy",
+      "routeKind": "trust",
+      "title": "Editorial Policy",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/password-safety-checklist",
+      "routeKind": "hub",
+      "title": "Password Safety Checklist",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/privacy",
+      "routeKind": "trust",
+      "title": "Privacy",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/recommended-tools",
+      "routeKind": "hub",
+      "title": "Recommended Tools",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    },
+    {
+      "url": "/terms",
+      "routeKind": "trust",
+      "title": "Terms",
+      "date": null,
+      "category": null,
+      "wordCount": null,
+      "internalLinks": null,
+      "credibleSources": null,
+      "affiliateLinks": null,
+      "sitemapPresent": true,
+      "qualityFlags": [],
+      "decision": "keep",
+      "destination": null,
+      "rationale": "Core utility, trust, or navigation route."
+    }
+  ]
+}

--- a/docs/URL_DECISION_MANIFEST.md
+++ b/docs/URL_DECISION_MANIFEST.md
@@ -1,0 +1,156 @@
+# SPG URL Decision Manifest
+
+> Proposed classifications only. Production mutation requires a separate approved issue.
+
+Generated deterministically by `npm run audit:urls` from the sitemap and article inventory.
+
+## Summary
+
+- Total URLs: **90** (12 static and 78 articles)
+- Keep: **12**
+- Rewrite: **30**
+- Consolidate: **28**
+- Remove: **20**
+
+## Consolidation clusters
+
+### business password managers
+
+Destination: /blog/best-password-manager-for-business-2026
+
+Sources: /blog/password-manager-for-business
+
+### authenticators and 2FA
+
+Destination: /blog/two-factor-authentication-guide
+
+Sources: /blog/google-authenticator-vs-authy, /blog/mfa-fatigue-attack-explained, /blog/microsoft-authenticator-guide, /blog/sim-swapping-protection, /blog/yubikey-setup-guide
+
+### breach and identity response
+
+Destination: /blog/data-breach-what-to-do
+
+Sources: /blog/dark-web-monitoring-explained, /blog/data-broker-opt-out-guide, /blog/how-to-check-if-youve-been-hacked, /blog/how-to-freeze-your-credit, /blog/how-to-recover-from-identity-theft, /blog/identity-theft-protection-guide, /blog/identity-theft-statistics-2026
+
+### VPN and public Wi-Fi
+
+Destination: /blog/public-wifi-security-tips
+
+Sources: /blog/how-to-use-a-vpn-for-privacy, /blog/vpn-for-remote-work, /blog/wifi-password-best-practices
+
+### account-specific security
+
+Destination: multiple retained account guides
+
+Sources: /blog/email-security-best-practices-2026, /blog/microsoft-account-security-guide, /blog/securing-facebook-account, /blog/securing-google-account, /blog/securing-linkedin-account, /blog/securing-venmo-cashapp-paypal
+
+### network and browser security
+
+Destination: /blog/browser-security-settings
+
+Sources: /blog/securing-home-network
+
+## 30/60/90-day stop-loss
+
+| Checkpoint | Search threshold | Affiliate threshold |
+|---|---|---|
+| Day 30 | At least 50 organic impressions across retained editorial URLs. | At least 3 tracked outbound affiliate clicks. |
+| Day 60 | At least 150 organic impressions and 2 organic clicks across retained editorial URLs. | At least 10 tracked outbound affiliate clicks. |
+| Day 90 | At least 300 organic impressions and 5 organic clicks across retained editorial URLs. | At least 20 tracked outbound affiliate clicks or 1 attributed conversion. |
+
+If a checkpoint misses both thresholds, stop publishing, diagnose indexing and intent fit, and consolidate or exit the underperforming cluster before investing further.
+
+## URL inventory
+
+| URL | Kind | Title | Date | Category | Words | Internal | Sources | Affiliate | Sitemap | Flags | Decision | Destination |
+|---|---|---|---|---|---:|---:|---:|---:|---|---|---|---|
+| / | utility | Strong Password Generator | — | — | — | — | — | — | yes | none | keep | — |
+| /about | trust | About | — | — | — | — | — | — | yes | none | keep | — |
+| /blog | hub | Blog | — | — | — | — | — | — | yes | none | keep | — |
+| /blog/ai-voice-cloning-scams | article | AI Voice Cloning Scams: How to Protect Yourself and Your Family | 2026-07-17 | Best Practices | 1363 | 6 | 0 | 3 | yes | missing-description; no-credible-external-sources; off-topic-reviewed-removal | remove | — |
+| /blog/android-password-tips | article | Android Password Security Tips: How to Lock Down Your Phone and Accounts | 2026-05-17 | Best Practices | 1522 | 3 | 3 | 3 | yes | missing-description | consolidate-to | /blog/how-to-create-strong-password |
+| /blog/antivirus-software-guide | article | Antivirus Software Guide 2026: Do You Need It, Which to Choose, and How to Configure It | 2026-06-16 | Best Practices | 1413 | 3 | 5 | 6 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/best-antivirus-software-2026 | article | Best Antivirus Software of 2026: How to Choose the Right Protection | 2026-05-24 | Best Practices | 1473 | 2 | 5 | 2 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/best-identity-theft-protection-2026 | article | Best Identity Theft Protection Services (2026): Compared and Reviewed | 2026-06-12 | Best Practices | 1232 | 5 | 0 | 4 | yes | missing-description; no-credible-external-sources | remove | — |
+| /blog/best-password-manager-for-business-2026 | article | Best Password Manager for Small Business and Teams (2026) | 2026-06-12 | Password Managers | 1296 | 6 | 3 | 3 | yes | missing-description | rewrite | — |
+| /blog/best-password-manager-for-families-2026 | article | Best Password Manager for Families in 2026: Shared Vaults, Emergency Access, and Kid-Safe Setup | 2026-07-03 | Password Managers | 1220 | 6 | 4 | 5 | yes | missing-description | rewrite | — |
+| /blog/best-password-manager-iphone-ios-2026 | article | Best Password Manager for iPhone and iOS (2026): Top 5 Compared | 2026-06-16 | Password Managers | 1217 | 5 | 3 | 3 | yes | missing-description | rewrite | — |
+| /blog/bitwarden-setup-guide | article | Bitwarden Setup Guide: How to Get Started with the Best Free Password Manager | 2026-04-15 | Password Managers | 1616 | 2 | 2 | 2 | yes | none | rewrite | — |
+| /blog/bitwarden-vs-1password-2026 | article | Bitwarden vs 1Password (2026): Which Password Manager Should You Use? | 2026-06-10 | Password Managers | 1310 | 5 | 6 | 2 | yes | missing-description | rewrite | — |
+| /blog/browser-security-settings | article | Browser Security Settings: The Complete Hardening Guide for Chrome, Firefox, and Safari | 2026-05-21 | Best Practices | 1297 | 5 | 1 | 2 | yes | missing-description | rewrite | — |
+| /blog/credential-stuffing-explained | article | Credential Stuffing Explained: What It Is and How to Stop It | 2026-06-23 | Password Security | 1534 | 6 | 1 | 4 | yes | missing-description | rewrite | — |
+| /blog/dark-web-monitoring-explained | article | Dark Web Monitoring Explained: What It Is, How It Works, and Do You Need It? | 2026-05-27 | Best Practices | 1362 | 3 | 0 | 5 | yes | missing-description; no-credible-external-sources | consolidate-to | /blog/data-breach-what-to-do |
+| /blog/data-breach-what-to-do | article | Data Breach: What to Do Immediately if Your Information Is Exposed | 2026-05-17 | Data Breaches | 1765 | 3 | 4 | 6 | yes | none | rewrite | — |
+| /blog/data-broker-opt-out-guide | article | How to Remove Your Personal Information From Data Broker Sites | 2026-07-16 | Data Breaches | 1447 | 4 | 0 | 3 | yes | missing-description; no-credible-external-sources | consolidate-to | /blog/data-breach-what-to-do |
+| /blog/email-security-best-practices-2026 | article | Email Security Best Practices 2026: Protect Your Inbox from Hackers and Phishing | 2026-06-20 | Best Practices | 1677 | 5 | 2 | 4 | yes | missing-description | consolidate-to | /blog/securing-your-email-account |
+| /blog/encrypted-messaging-apps-guide | article | Encrypted Messaging Apps Compared: Signal vs. WhatsApp vs. iMessage vs. Telegram | 2026-07-02 | Best Practices | 1023 | 4 | 0 | 2 | yes | missing-description; no-credible-external-sources; off-topic-reviewed-removal | remove | — |
+| /blog/free-vs-paid-password-managers-2026 | article | Free vs Paid Password Managers in 2026: What You Actually Get for Your Money | 2026-06-19 | Password Managers | 1364 | 5 | 3 | 4 | yes | missing-description | rewrite | — |
+| /blog/github-security-best-practices | article | GitHub Security Best Practices: Protect Your Code and Account | 2026-04-28 | Best Practices | 1869 | 6 | 2 | 3 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/google-authenticator-vs-authy | article | Google Authenticator vs. Authy: Which 2FA App Should You Use in 2026? | 2026-06-21 | 2FA | 1473 | 5 | 3 | 3 | yes | missing-description | consolidate-to | /blog/two-factor-authentication-guide |
+| /blog/google-password-manager-review | article | Google Password Manager Review 2026: Is It Good Enough for Your Security? | 2026-04-28 | Password Managers | 1660 | 6 | 4 | 7 | yes | missing-description | rewrite | — |
+| /blog/how-to-check-if-youve-been-hacked | article | How to Check If You've Been Hacked: Warning Signs and What to Do Next | 2026-06-17 | Best Practices | 1653 | 10 | 0 | 4 | yes | no-credible-external-sources | consolidate-to | /blog/data-breach-what-to-do |
+| /blog/how-to-create-strong-password | article | How to Create a Strong Password: The Complete Guide for 2026 | 2026-06-18 | Password Security | 1421 | 7 | 2 | 2 | yes | none | rewrite | — |
+| /blog/how-to-freeze-your-credit | article | How to Freeze Your Credit: The Complete Step-by-Step Guide | 2026-05-28 | Best Practices | 2079 | 5 | 0 | 4 | yes | missing-description; no-credible-external-sources | consolidate-to | /blog/data-breach-what-to-do |
+| /blog/how-to-recover-from-identity-theft | article | How to Recover from Identity Theft: A Complete Step-by-Step Action Plan | 2026-06-22 | Data Breaches | 1877 | 8 | 4 | 4 | yes | missing-description | consolidate-to | /blog/data-breach-what-to-do |
+| /blog/how-to-share-passwords-safely | article | How to Share Passwords Safely (Without Texting or Emailing Them) | 2026-07-16 | Password Managers | 1380 | 10 | 1 | 2 | yes | missing-description | rewrite | — |
+| /blog/how-to-spot-fake-websites | article | How to Spot Fake Websites: A Practical Guide to Avoiding Phishing and Scam Sites | 2026-05-25 | Best Practices | 1462 | 2 | 2 | 2 | yes | missing-description | rewrite | — |
+| /blog/how-to-use-a-vpn-for-privacy | article | How to Use a VPN for Privacy: A Practical Guide (2026) | 2026-06-12 | Best Practices | 1833 | 8 | 0 | 7 | yes | missing-description; no-credible-external-sources | consolidate-to | /blog/public-wifi-security-tips |
+| /blog/identity-theft-protection-guide | article | Identity Theft Protection Guide: How to Secure Your Personal Data in 2026 | 2026-05-23 | Best Practices | 1473 | 4 | 4 | 2 | yes | none | consolidate-to | /blog/data-breach-what-to-do |
+| /blog/identity-theft-statistics-2026 | article | Identity Theft Statistics 2026: What the Data Actually Shows | 2026-06-02 | Data Breaches | 1891 | 6 | 2 | 5 | yes | missing-description | consolidate-to | /blog/data-breach-what-to-do |
+| /blog/iphone-password-security | article | Complete iPhone Password Security Guide: Protecting Your Apple ID & Accounts | 2026-04-30 | Best Practices | 2018 | 3 | 3 | 4 | yes | missing-description | consolidate-to | /blog/securing-apple-id |
+| /blog/lastpass-alternatives | article | The Best LastPass Alternatives in 2026: Safer, Cheaper, Better Options | 2026-05-05 | Password Managers | 1247 | 6 | 2 | 2 | yes | missing-description | rewrite | — |
+| /blog/mfa-fatigue-attack-explained | article | MFA Fatigue Attacks: How Push Notification Abuse Bypasses Two-Factor Authentication | 2026-06-23 | 2FA | 1505 | 7 | 0 | 6 | yes | missing-description; no-credible-external-sources | consolidate-to | /blog/two-factor-authentication-guide |
+| /blog/microsoft-account-security-guide | article | How to Secure Your Microsoft Account: Passwords, 2FA, and Recovery Options | 2026-06-19 | Best Practices | 1534 | 6 | 2 | 5 | yes | missing-description | consolidate-to | /blog/securing-your-email-account |
+| /blog/microsoft-authenticator-guide | article | Microsoft Authenticator Guide: Set Up Strong 2FA on Every Account | 2026-05-12 | 2FA | 1924 | 4 | 2 | 2 | yes | missing-description | consolidate-to | /blog/two-factor-authentication-guide |
+| /blog/nordpass-review-2026 | article | NordPass Review 2026: Is This Password Manager Worth It? | 2026-06-29 | Password Managers | 1461 | 10 | 1 | 3 | yes | none | rewrite | — |
+| /blog/nordpass-vs-dashlane-2026 | article | NordPass vs Dashlane (2026): Which Password Manager Is Better? | 2026-06-11 | Password Managers | 1458 | 8 | 1 | 7 | yes | none | rewrite | — |
+| /blog/nordprotect-review-2026 | article | NordProtect Review 2026: Is This Identity Protection Service Worth It? | 2026-06-11 | Data Breaches | 1758 | 4 | 0 | 11 | yes | missing-description; no-credible-external-sources | remove | — |
+| /blog/nordvpn-review-2026 | article | NordVPN Review 2026: Is It Still the Best VPN for Privacy and Security? | 2026-06-14 | Password Security | 1245 | 6 | 1 | 4 | yes | missing-description | remove | — |
+| /blog/nordvpn-vs-expressvpn | article | NordVPN vs ExpressVPN (2026): Which VPN Is Worth Your Money? | 2026-06-15 | Best Practices | 1537 | 4 | 1 | 7 | yes | missing-description | remove | — |
+| /blog/passkeys-explained | article | Passkeys Explained: The Future of Passwordless Login and How to Use Them | 2026-05-17 | Best Practices | 2024 | 6 | 5 | 4 | yes | missing-description | rewrite | — |
+| /blog/passkeys-vs-passwords-2026 | article | Are Passkeys Replacing Passwords in 2026? The Complete Guide | 2026-06-14 | Security Trends | 1804 | 6 | 5 | 6 | yes | missing-description | rewrite | — |
+| /blog/password-hygiene-for-families | article | Password Hygiene for Families: How to Keep Every Household Account Secure | 2026-05-08 | Best Practices | 2438 | 6 | 4 | 2 | yes | missing-description | rewrite | — |
+| /blog/password-manager-for-business | article | Password Manager for Business: How to Secure Your Team's Credentials in 2026 | 2026-06-17 | Password Managers | 1483 | 4 | 2 | 2 | yes | missing-description | consolidate-to | /blog/best-password-manager-for-business-2026 |
+| /blog/password-manager-for-college-students | article | Best Password Manager Setup for College Students (Free Options Included) | 2026-07-17 | Password Managers | 1306 | 8 | 0 | 3 | yes | missing-description; no-credible-external-sources | consolidate-to | /blog/free-vs-paid-password-managers-2026 |
+| /blog/password-manager-vs-browser-autofill | article | Password Manager vs. Browser Autofill: Which Is Actually More Secure? | 2026-06-18 | Password Managers | 1338 | 4 | 3 | 5 | yes | missing-description | rewrite | — |
+| /blog/password-managers | hub | Blog/Password Managers | — | — | — | — | — | — | yes | none | keep | — |
+| /blog/password-reuse-risks | article | The Dangers of Password Reuse: Why Using the Same Password Everywhere Is a Security Disaster | 2026-06-22 | Password Security | 1869 | 8 | 3 | 5 | yes | missing-description | rewrite | — |
+| /blog/password-security | hub | Blog/Password Security | — | — | — | — | — | — | yes | none | keep | — |
+| /blog/password-security-audit-checklist | article | Password Security Audit Checklist: 20 Steps to Harden Every Account You Own | 2026-05-12 | Best Practices | 1582 | 6 | 3 | 2 | yes | missing-description | consolidate-to | /blog/how-to-create-strong-password |
+| /blog/password-security-for-remote-workers | article | Password Security for Remote Workers: How to Stay Safe Outside the Office | 2026-04-16 | Best Practices | 2064 | 2 | 2 | 4 | yes | missing-description | rewrite | — |
+| /blog/password-security-for-seniors | article | Password Security for Seniors: A Simple, Step-by-Step Guide | 2026-05-05 | Best Practices | 2472 | 6 | 0 | 6 | yes | missing-description; no-credible-external-sources | rewrite | — |
+| /blog/phishing | hub | Blog/Phishing | — | — | — | — | — | — | yes | none | keep | — |
+| /blog/protecting-kids-online | article | Protecting Kids Online: A Parent's Complete Guide to Account Security | 2026-05-25 | Best Practices | 1620 | 4 | 4 | 2 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/public-wifi-security-tips | article | Public Wi-Fi Security: How to Stay Safe on Unsecured Networks | 2026-06-29 | Best Practices | 1520 | 6 | 0 | 5 | yes | missing-description; no-credible-external-sources | rewrite | — |
+| /blog/qr-code-scam-quishing-guide | article | QR Code Scams ("Quishing"): How They Work and How to Spot One | 2026-07-19 | Best Practices | 1003 | 3 | 0 | 2 | yes | missing-description; no-credible-external-sources | consolidate-to | /blog/what-is-phishing-and-how-to-avoid-it |
+| /blog/securing-apple-id | article | How to Secure Your Apple ID: The Complete Protection Guide | 2026-05-18 | Best Practices | 1857 | 4 | 2 | 3 | yes | missing-description | rewrite | — |
+| /blog/securing-cloud-storage | article | How to Secure Your Cloud Storage: Google Drive, iCloud, Dropbox, and OneDrive | 2026-06-15 | Best Practices | 1295 | 5 | 4 | 6 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/securing-crypto-wallets | article | How to Secure Your Crypto Wallet: Passwords, Seed Phrases, and Account Protection | 2026-05-17 | Best Practices | 1827 | 7 | 2 | 3 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/securing-facebook-account | article | How to Secure Your Facebook Account: The Complete 2026 Guide | 2026-06-21 | Best Practices | 1534 | 5 | 1 | 8 | yes | missing-description | consolidate-to | /blog/securing-social-media-accounts |
+| /blog/securing-google-account | article | How to Secure Your Google Account: A Complete Checklist | 2026-07-19 | Best Practices | 1008 | 6 | 0 | 2 | yes | missing-description; no-credible-external-sources | consolidate-to | /blog/securing-your-email-account |
+| /blog/securing-home-network | article | How to Secure Your Home Network: A Step-by-Step Guide to Router and Wi-Fi Security | 2026-05-17 | Best Practices | 1568 | 3 | 2 | 6 | yes | missing-description | consolidate-to | /blog/browser-security-settings |
+| /blog/securing-linkedin-account | article | How to Secure Your LinkedIn Account: Passwords, 2FA, and Privacy Settings | 2026-05-23 | Best Practices | 1665 | 6 | 3 | 6 | yes | missing-description | consolidate-to | /blog/securing-social-media-accounts |
+| /blog/securing-online-banking | article | Secure Online Banking: How to Protect Your Bank Account from Hacking | 2026-04-30 | Best Practices | 1500 | 9 | 2 | 6 | yes | missing-description | rewrite | — |
+| /blog/securing-remote-desktop-rdp | article | How to Secure Remote Desktop Access: RDP, VPNs, and Remote Work Security in 2026 | 2026-06-20 | Best Practices | 1734 | 6 | 3 | 5 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/securing-smart-home-devices | article | How to Secure Your Smart Home Devices in 2026 | 2026-06-11 | Best Practices | 1333 | 4 | 1 | 4 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/securing-social-media-accounts | article | How to Secure Your Social Media Accounts: A Practical Guide | 2026-04-16 | Best Practices | 1963 | 3 | 2 | 4 | yes | missing-description | rewrite | — |
+| /blog/securing-venmo-cashapp-paypal | article | How to Secure Your Venmo, Cash App, and PayPal Accounts | 2026-07-02 | Best Practices | 1258 | 8 | 1 | 2 | yes | missing-description | consolidate-to | /blog/securing-online-banking |
+| /blog/securing-your-amazon-account | article | How to Secure Your Amazon Account: A Complete Security Guide | 2026-05-22 | Best Practices | 1691 | 9 | 2 | 2 | yes | missing-description | remove | — |
+| /blog/securing-your-email-account | article | How to Secure Your Email Account: The Complete Guide | 2026-04-15 | Best Practices | 1752 | 3 | 4 | 2 | yes | missing-description | rewrite | — |
+| /blog/sim-swapping-protection | article | SIM Swapping Protection: How to Stop Attackers From Hijacking Your Phone Number | 2026-05-22 | Best Practices | 1691 | 6 | 2 | 7 | yes | missing-description | consolidate-to | /blog/two-factor-authentication-guide |
+| /blog/two-factor-authentication-guide | article | Two-Factor Authentication Guide: How to Enable 2FA on Every Important Account | 2026-05-17 | 2FA | 1339 | 7 | 3 | 5 | yes | missing-description | rewrite | — |
+| /blog/vpn-for-remote-work | article | VPN for Remote Work: How to Stay Secure Working Outside the Office | 2026-05-18 | Best Practices | 1921 | 6 | 2 | 8 | yes | missing-description | consolidate-to | /blog/public-wifi-security-tips |
+| /blog/vpn-vs-password-manager | article | VPN vs Password Manager: Do You Need Both? | 2026-06-11 | Best Practices | 1180 | 6 | 3 | 8 | yes | missing-description | remove | — |
+| /blog/vpn-worth-it-2026 | article | Is a VPN Worth It in 2026? An Honest Look at What VPNs Do and Don't Protect | 2026-06-11 | Best Practices | 1839 | 6 | 0 | 7 | yes | missing-description; no-credible-external-sources | remove | — |
+| /blog/what-is-nordprotect | article | What Is NordProtect? Identity Theft Protection Explained | 2026-06-14 | Password Security | 1252 | 6 | 0 | 7 | yes | missing-description; no-credible-external-sources | remove | — |
+| /blog/what-is-phishing-and-how-to-avoid-it | article | What Is Phishing and How to Avoid It: A Practical Guide | 2026-04-21 | Best Practices | 2177 | 6 | 3 | 5 | yes | missing-description | rewrite | — |
+| /blog/wifi-password-best-practices | article | Wi-Fi Password Best Practices: How to Secure Your Home and Office Network | 2026-04-21 | Best Practices | 1885 | 1 | 3 | 4 | yes | missing-description; few-internal-links | consolidate-to | /blog/public-wifi-security-tips |
+| /blog/wordpress-security-passwords | article | WordPress Security: How to Lock Down Passwords, Logins, and Admin Access | 2026-06-16 | Best Practices | 1561 | 4 | 2 | 3 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /blog/yubikey-setup-guide | article | YubiKey Setup Guide: How to Use a Hardware Security Key for Maximum Protection | 2026-05-08 | 2FA | 1752 | 2 | 2 | 2 | yes | missing-description | consolidate-to | /blog/two-factor-authentication-guide |
+| /blog/zero-trust-security-basics | article | Zero Trust Security Explained: A Practical Guide for Individuals and Small Businesses | 2026-05-24 | Best Practices | 1749 | 8 | 3 | 6 | yes | missing-description; off-topic-reviewed-removal | remove | — |
+| /contact | trust | Contact | — | — | — | — | — | — | yes | none | keep | — |
+| /editorial-policy | trust | Editorial Policy | — | — | — | — | — | — | yes | none | keep | — |
+| /password-safety-checklist | hub | Password Safety Checklist | — | — | — | — | — | — | yes | none | keep | — |
+| /privacy | trust | Privacy | — | — | — | — | — | — | yes | none | keep | — |
+| /recommended-tools | hub | Recommended Tools | — | — | — | — | — | — | yes | none | keep | — |
+| /terms | trust | Terms | — | — | — | — | — | — | yes | none | keep | — |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "tsc --noEmit false --incremental false --esModuleInterop true --module commonjs --moduleResolution node --target es2020 --outDir /tmp/spg-issue-435-tests --types node src/lib/password-generator.test.ts src/lib/privacy.test.ts src/lib/analytics.test.ts && node --test /tmp/spg-issue-435-tests/*.test.js",
     "lint": "eslint",
     "check:adsense": "node scripts/check-adsense-readiness.mjs",
-    "audit:content": "node scripts/audit-content-quality.mjs"
+    "audit:content": "node scripts/audit-content-quality.mjs",
+    "audit:urls": "node scripts/audit-url-decisions.mjs"
   },
   "dependencies": {
     "next": "16.1.6",

--- a/scripts/audit-url-decisions.mjs
+++ b/scripts/audit-url-decisions.mjs
@@ -1,0 +1,222 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const BASE_URL = 'https://strongpasswordgenerator.dev';
+const POSTS_DIR = 'src/posts';
+const INDEX_PATH = path.join(POSTS_DIR, 'index.json');
+const SITEMAP_PATH = 'src/app/sitemap.ts';
+const JSON_PATH = 'docs/URL_DECISION_MANIFEST.json';
+const MARKDOWN_PATH = 'docs/URL_DECISION_MANIFEST.md';
+const AFFILIATE_HOSTS = ['awin1.com', 'kqzyfj.com', 'nordpass.com', 'nordvpn.com', 'coveron.com'];
+
+const REWRITE = new Set([
+  'how-to-create-strong-password', 'password-reuse-risks', 'credential-stuffing-explained',
+  'two-factor-authentication-guide', 'passkeys-explained', 'passkeys-vs-passwords-2026',
+  'data-breach-what-to-do', 'what-is-phishing-and-how-to-avoid-it', 'how-to-spot-fake-websites',
+  'bitwarden-setup-guide', 'password-manager-vs-browser-autofill', 'free-vs-paid-password-managers-2026',
+  'best-password-manager-for-families-2026', 'best-password-manager-for-business-2026',
+  'best-password-manager-iphone-ios-2026', 'bitwarden-vs-1password-2026', 'google-password-manager-review',
+  'nordpass-review-2026', 'nordpass-vs-dashlane-2026', 'lastpass-alternatives',
+  'how-to-share-passwords-safely', 'password-hygiene-for-families', 'password-security-for-seniors',
+  'password-security-for-remote-workers', 'public-wifi-security-tips', 'securing-your-email-account',
+  'securing-social-media-accounts', 'securing-online-banking', 'browser-security-settings',
+  'securing-apple-id',
+]);
+
+const OFF_TOPIC_REMOVE = new Set([
+  'ai-voice-cloning-scams', 'antivirus-software-guide', 'best-antivirus-software-2026',
+  'encrypted-messaging-apps-guide', 'github-security-best-practices', 'protecting-kids-online',
+  'securing-cloud-storage', 'securing-crypto-wallets', 'securing-remote-desktop-rdp',
+  'securing-smart-home-devices', 'wordpress-security-passwords', 'zero-trust-security-basics',
+]);
+
+const NON_EQUIVALENT_REMOVE = new Set([
+  'best-identity-theft-protection-2026', 'nordprotect-review-2026', 'what-is-nordprotect',
+  'nordvpn-review-2026', 'nordvpn-vs-expressvpn', 'vpn-worth-it-2026',
+  'vpn-vs-password-manager', 'securing-your-amazon-account',
+]);
+
+const CONSOLIDATE = new Map(Object.entries({
+  'password-manager-for-business': 'best-password-manager-for-business-2026',
+  'password-manager-for-college-students': 'free-vs-paid-password-managers-2026',
+  'google-authenticator-vs-authy': 'two-factor-authentication-guide',
+  'microsoft-authenticator-guide': 'two-factor-authentication-guide',
+  'yubikey-setup-guide': 'two-factor-authentication-guide',
+  'mfa-fatigue-attack-explained': 'two-factor-authentication-guide',
+  'data-broker-opt-out-guide': 'data-breach-what-to-do',
+  'how-to-recover-from-identity-theft': 'data-breach-what-to-do',
+  'identity-theft-protection-guide': 'data-breach-what-to-do',
+  'identity-theft-statistics-2026': 'data-breach-what-to-do',
+  'dark-web-monitoring-explained': 'data-breach-what-to-do',
+  'how-to-freeze-your-credit': 'data-breach-what-to-do',
+  'how-to-use-a-vpn-for-privacy': 'public-wifi-security-tips',
+  'vpn-for-remote-work': 'public-wifi-security-tips',
+  'email-security-best-practices-2026': 'securing-your-email-account',
+  'securing-google-account': 'securing-your-email-account',
+  'microsoft-account-security-guide': 'securing-your-email-account',
+  'securing-facebook-account': 'securing-social-media-accounts',
+  'securing-linkedin-account': 'securing-social-media-accounts',
+  'securing-venmo-cashapp-paypal': 'securing-online-banking',
+  'wifi-password-best-practices': 'public-wifi-security-tips',
+  'securing-home-network': 'browser-security-settings',
+  'android-password-tips': 'how-to-create-strong-password',
+  'iphone-password-security': 'securing-apple-id',
+  'password-security-audit-checklist': 'how-to-create-strong-password',
+  'how-to-check-if-youve-been-hacked': 'data-breach-what-to-do',
+  'qr-code-scam-quishing-guide': 'what-is-phishing-and-how-to-avoid-it',
+  'sim-swapping-protection': 'two-factor-authentication-guide',
+}));
+
+const CLUSTERS = [
+  { name: 'business password managers', destination: '/blog/best-password-manager-for-business-2026', sources: ['/blog/password-manager-for-business'] },
+  { name: 'authenticators and 2FA', destination: '/blog/two-factor-authentication-guide', sources: [...CONSOLIDATE].filter(([, d]) => d === 'two-factor-authentication-guide').map(([s]) => `/blog/${s}`).sort() },
+  { name: 'breach and identity response', destination: '/blog/data-breach-what-to-do', sources: [...CONSOLIDATE].filter(([, d]) => d === 'data-breach-what-to-do').map(([s]) => `/blog/${s}`).sort() },
+  { name: 'VPN and public Wi-Fi', destination: '/blog/public-wifi-security-tips', sources: [...CONSOLIDATE].filter(([, d]) => d === 'public-wifi-security-tips').map(([s]) => `/blog/${s}`).sort() },
+  { name: 'account-specific security', destination: 'multiple retained account guides', sources: [...CONSOLIDATE].filter(([, d]) => ['securing-your-email-account', 'securing-social-media-accounts', 'securing-online-banking'].includes(d)).map(([s]) => `/blog/${s}`).sort() },
+  { name: 'network and browser security', destination: '/blog/browser-security-settings', sources: [...CONSOLIDATE].filter(([, d]) => d === 'browser-security-settings').map(([s]) => `/blog/${s}`).sort() },
+];
+
+function visibleWords(html = '') {
+  return html.replace(/<script[\s\S]*?<\/script>/gi, ' ').replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ').replace(/&[a-z#0-9]+;/gi, ' ').trim().split(/\s+/).filter(Boolean).length;
+}
+
+function hrefs(html = '') {
+  return [...html.matchAll(/href=["']([^"']+)["']/gi)].map((match) => match[1]);
+}
+
+function isAffiliate(url) {
+  return AFFILIATE_HOSTS.some((host) => url.includes(host));
+}
+
+function escapeCell(value) {
+  return String(value).replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+async function json(file) {
+  try { return JSON.parse(await readFile(file, 'utf8')); }
+  catch (error) { throw new Error(`${file}: ${error.message}`); }
+}
+
+async function main() {
+  const index = await json(INDEX_PATH);
+  if (!Array.isArray(index)) throw new Error(`${INDEX_PATH} must be an array`);
+  const files = (await readdir(POSTS_DIR)).filter((file) => file.endsWith('.json') && file !== 'index.json').sort();
+  const slugs = index.map((post) => post.slug);
+  if (new Set(slugs).size !== slugs.length) throw new Error('Article index contains duplicate slugs');
+  const expectedFiles = slugs.map((slug) => `${slug}.json`).sort();
+  if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) throw new Error('Article records and files are not a one-to-one match');
+
+  const sitemapSource = await readFile(SITEMAP_PATH, 'utf8');
+  const staticSection = sitemapSource.split('export default function sitemap')[0];
+  const staticPaths = [...staticSection.matchAll(/url:\s*(?:BASE_URL|`\$\{BASE_URL\})([^`]*?)`?,/g)]
+    .map((match) => match[1] || '/').map((route) => route || '/');
+  if (!staticPaths.includes('/') || staticPaths.length !== 12) throw new Error(`Expected 12 static sitemap routes, found ${staticPaths.length}`);
+
+  const articleRows = [];
+  for (const record of index) {
+    const post = await json(path.join(POSTS_DIR, `${record.slug}.json`));
+    if (post.slug !== record.slug) throw new Error(`${record.slug}: record/file slug mismatch`);
+    const links = hrefs(post.content);
+    const external = links.filter((url) => /^https?:\/\//i.test(url));
+    const flags = [];
+    const wordCount = visibleWords(post.content);
+    const sources = external.filter((url) => !isAffiliate(url)).length;
+    if (!(post.description || post.metaDescription)) flags.push('missing-description');
+    if (wordCount < 800) flags.push('thin-under-800-words');
+    if (links.filter((url) => url.startsWith('/')).length < 2) flags.push('few-internal-links');
+    if (!sources) flags.push('no-credible-external-sources');
+
+    if (OFF_TOPIC_REMOVE.has(record.slug)) flags.push('off-topic-reviewed-removal');
+
+    let decision = 'remove';
+    let destination = null;
+    let rationale = OFF_TOPIC_REMOVE.has(record.slug)
+      ? 'Explicitly reviewed as off-topic for a focused password-generation site.'
+      : NON_EQUIVALENT_REMOVE.has(record.slug)
+        ? 'Remove because no retained URL is a genuinely equivalent redirect destination.'
+        : 'Outside the reviewed, focused editorial shortlist.';
+    if (REWRITE.has(record.slug)) {
+      decision = 'rewrite';
+      rationale = 'Reviewed editorial shortlist aligned to core user intent.';
+    } else if (CONSOLIDATE.has(record.slug)) {
+      decision = 'consolidate-to';
+      destination = `/blog/${CONSOLIDATE.get(record.slug)}`;
+      rationale = 'Overlapping intent belongs in a stronger retained destination.';
+    }
+    articleRows.push({
+      url: `/blog/${record.slug}`, routeKind: 'article', title: post.title || record.title,
+      date: post.date || record.date, category: post.category || record.category, wordCount,
+      internalLinks: links.filter((url) => url.startsWith('/')).length, credibleSources: sources,
+      affiliateLinks: external.filter(isAffiliate).length, sitemapPresent: true,
+      qualityFlags: flags, decision, destination, rationale,
+    });
+  }
+
+  const staticRows = staticPaths.map((url) => ({
+    url, routeKind: url === '/' ? 'utility' : ['about', 'contact', 'privacy', 'terms', 'editorial-policy'].some((part) => url === `/${part}`) ? 'trust' : 'hub',
+    title: url === '/' ? 'Strong Password Generator' : url.slice(1).replaceAll('-', ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+    date: null, category: null, wordCount: null, internalLinks: null, credibleSources: null,
+    affiliateLinks: null, sitemapPresent: true, qualityFlags: [], decision: 'keep', destination: null,
+    rationale: 'Core utility, trust, or navigation route.',
+  }));
+  const rows = [...staticRows, ...articleRows].sort((a, b) => a.url.localeCompare(b.url));
+  if (new Set(rows.map((row) => row.url)).size !== rows.length) throw new Error('Manifest URLs are not unique');
+  if (rows.length !== staticPaths.length + index.length) throw new Error('Manifest does not cover every sitemap URL exactly once');
+  const decisions = new Set(['keep', 'rewrite', 'consolidate-to', 'remove']);
+  if (rows.some((row) => !decisions.has(row.decision))) throw new Error('Unsupported decision found');
+  const rowByUrl = new Map(rows.map((row) => [row.url, row]));
+  for (const slug of NON_EQUIVALENT_REMOVE) {
+    if (rowByUrl.get(`/blog/${slug}`)?.decision !== 'remove') throw new Error(`${slug}: non-equivalent URL must be removed`);
+  }
+  for (const row of rows.filter((item) => item.decision === 'consolidate-to')) {
+    const target = rowByUrl.get(row.destination);
+    if (!target || !['keep', 'rewrite'].includes(target.decision)) throw new Error(`${row.url}: invalid consolidation destination ${row.destination}`);
+    if (row.url === row.destination) throw new Error(`${row.url}: consolidation cannot target itself`);
+  }
+
+  const counts = Object.fromEntries([...decisions].map((decision) => [decision, rows.filter((row) => row.decision === decision).length]));
+  const manifest = {
+    schemaVersion: 1, site: BASE_URL,
+    notice: 'Proposed classifications only. Production mutation requires a separate approved issue.',
+    inventory: { staticSitemapRoutes: staticRows.length, articleRecords: articleRows.length, articleFiles: files.length, totalUrls: rows.length },
+    decisionCounts: counts,
+    editorialShortlist: [...REWRITE].map((slug) => `/blog/${slug}`).sort(),
+    consolidationClusters: CLUSTERS,
+    stopLoss: {
+      day30: { search: 'At least 50 organic impressions across retained editorial URLs.', affiliate: 'At least 3 tracked outbound affiliate clicks.' },
+      day60: { search: 'At least 150 organic impressions and 2 organic clicks across retained editorial URLs.', affiliate: 'At least 10 tracked outbound affiliate clicks.' },
+      day90: { search: 'At least 300 organic impressions and 5 organic clicks across retained editorial URLs.', affiliate: 'At least 20 tracked outbound affiliate clicks or 1 attributed conversion.' },
+      action: 'If a checkpoint misses both thresholds, stop publishing, diagnose indexing and intent fit, and consolidate or exit the underperforming cluster before investing further.',
+    },
+    urls: rows,
+  };
+  const serialized = `${JSON.stringify(manifest, null, 2)}\n`;
+  await writeFile(JSON_PATH, serialized, 'utf8');
+
+  const markdown = [
+    '# SPG URL Decision Manifest', '',
+    '> Proposed classifications only. Production mutation requires a separate approved issue.', '',
+    'Generated deterministically by `npm run audit:urls` from the sitemap and article inventory.', '',
+    '## Summary', '',
+    `- Total URLs: **${rows.length}** (${staticRows.length} static and ${articleRows.length} articles)`,
+    `- Keep: **${counts.keep}**`, `- Rewrite: **${counts.rewrite}**`,
+    `- Consolidate: **${counts['consolidate-to']}**`, `- Remove: **${counts.remove}**`, '',
+    '## Consolidation clusters', '',
+    ...CLUSTERS.flatMap((cluster) => [`### ${cluster.name}`, '', `Destination: ${cluster.destination}`, '', `Sources: ${cluster.sources.join(', ') || 'none'}`, '']),
+    '## 30/60/90-day stop-loss', '',
+    '| Checkpoint | Search threshold | Affiliate threshold |', '|---|---|---|',
+    `| Day 30 | ${manifest.stopLoss.day30.search} | ${manifest.stopLoss.day30.affiliate} |`,
+    `| Day 60 | ${manifest.stopLoss.day60.search} | ${manifest.stopLoss.day60.affiliate} |`,
+    `| Day 90 | ${manifest.stopLoss.day90.search} | ${manifest.stopLoss.day90.affiliate} |`, '',
+    manifest.stopLoss.action, '', '## URL inventory', '',
+    '| URL | Kind | Title | Date | Category | Words | Internal | Sources | Affiliate | Sitemap | Flags | Decision | Destination |',
+    '|---|---|---|---|---|---:|---:|---:|---:|---|---|---|---|',
+    ...rows.map((row) => `| ${[row.url, row.routeKind, row.title, row.date ?? '—', row.category ?? '—', row.wordCount ?? '—', row.internalLinks ?? '—', row.credibleSources ?? '—', row.affiliateLinks ?? '—', row.sitemapPresent ? 'yes' : 'no', row.qualityFlags.join('; ') || 'none', row.decision, row.destination ?? '—'].map(escapeCell).join(' | ')} |`),
+    '',
+  ].join('\n');
+  await writeFile(MARKDOWN_PATH, markdown, 'utf8');
+  console.log(`Validated ${rows.length} URLs: ${counts.keep} keep, ${counts.rewrite} rewrite, ${counts['consolidate-to']} consolidate, ${counts.remove} remove`);
+}
+
+main().catch((error) => { console.error(error.message); process.exitCode = 1; });


### PR DESCRIPTION
## What changed

- inventories every current sitemap URL and article record exactly once
- classifies each URL as keep, rewrite, consolidate, or remove
- documents safe consolidation destinations and excludes non-equivalent redirects
- adds deterministic audit assertions and 30/60/90-day stop-loss thresholds

## Why

The site was rejected by AdSense for low-value content after an automated publishing pipeline created a broad, overlapping article inventory. This diagnostic manifest provides a reviewed, reproducible basis for a separate production consolidation change.

This PR does not alter production routes, content, redirects, or indexing.

## Validation

- `npm run audit:urls` (90 URLs: 12 keep, 30 rewrite, 28 consolidate, 20 remove)
- `npm test` (6 passing)
- `npm run lint`
- `npm run build` (94 static pages)
- `git diff --check`

Closes #439