### PR TITLE
growth: activate privacy-safe analytics baseline

### DIFF
--- a/scripts/check-analytics-readiness.mjs
+++ b/scripts/check-analytics-readiness.mjs
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const analyticsPath = path.join(process.cwd(), 'src/lib/analytics.ts');
+const analyticsSource = fs.readFileSync(analyticsPath, 'utf8');
+
+const requiredActions = [
+  'generator_success',
+  'copy',
+  'regenerate',
+  'recommendation_view',
+  'affiliate_click',
+  'newsletter_view',
+  'newsletter_action',
+];
+const forbiddenKeys = ['password', 'passphrase', 'checkerInput', 'entropyInput', 'email'];
+
+const allowedKeysMatch = analyticsSource.match(
+  /export const ALLOWED_EVENT_KEYS = \[([\s\S]*?)\] as const;/,
+);
+
+if (!allowedKeysMatch) {
+  console.error('Analytics readiness: FAIL — shared allowed-key contract was not found.');
+  process.exitCode = 1;
+} else {
+  const allowedKeys = [...allowedKeysMatch[1].matchAll(/'([^']+)'/g)].map((match) => match[1]);
+  const exposedSensitiveKeys = forbiddenKeys.filter((key) => allowedKeys.includes(key));
+  if (exposedSensitiveKeys.length > 0) {
+    console.error('Analytics readiness: FAIL — the event contract permits a forbidden sensitive key.');
+    process.exitCode = 1;
+  }
+}
+
+const missingActions = requiredActions.filter((action) => !analyticsSource.includes(`'${action}'`));
+if (missingActions.length > 0) {
+  console.error('Analytics readiness: FAIL — one or more required funnel actions are missing.');
+  process.exitCode = 1;
+}
+
+if (!measurementId) {
+  console.error('Analytics readiness: FAIL — NEXT_PUBLIC_GA_MEASUREMENT_ID is not configured.');
+  process.exitCode = 1;
+} else if (!/^G-[A-Z0-9]+$/.test(measurementId)) {
+  console.error('Analytics readiness: FAIL — NEXT_PUBLIC_GA_MEASUREMENT_ID has an invalid format.');
+  process.exitCode = 1;
+}
+
+if (!process.exitCode) {
+  console.log('Analytics readiness: PASS — GA is configured and the funnel contract is privacy-safe.');
+}

--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -1,4 +1,5 @@
 import Script from "next/script";
+import { createBrowserFunnelScript } from "@/lib/analytics";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
@@ -23,9 +24,10 @@ export default function Analytics() {
       ) : null}
       <Script id="income-click-tracking" strategy="afterInteractive">
         {`
+          ${createBrowserFunnelScript()}
+
           function funnelEvent(action, placement, extra) {
-            if (!window.gtag) return;
-            window.gtag('event', action, Object.assign({
+            return window.spgTrackFunnelEvent(Object.assign({
               action: action,
               page: window.location.pathname,
               placement: placement
@@ -34,7 +36,7 @@ export default function Analytics() {
 
           document.addEventListener('click', function(event) {
             var link = event.target && event.target.closest ? event.target.closest('a[href]') : null;
-            if (!link || !window.gtag) return;
+            if (!link) return;
 
             var url;
             try {
@@ -57,8 +59,6 @@ export default function Analytics() {
               var placement = link.closest('main') ? 'content' : link.closest('footer') ? 'footer' : 'site_navigation';
               if (isAffiliate) {
                 funnelEvent('affiliate_click', placement, { partner: partner });
-              } else {
-                funnelEvent('outbound_click', placement, { link_domain: url.hostname });
               }
             }
           });

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -131,7 +131,7 @@ export default function PrivacyPage() {
                 <li>Page views and general site analytics (via Google Analytics or hosting-provider analytics)</li>
                 <li>Referring URLs and general geographic region (country-level)</li>
                 <li>Browser type and device type (for compatibility)</li>
-                <li>Generator success, copy, regenerate, recommendation view, affiliate click, and newsletter interaction events, with page and placement context</li>
+                <li>Generator success, copy, regenerate, recommendation view, affiliate click, and newsletter interaction events, with anonymous page, placement, page-intent, generator-type, or affiliate-partner categories where relevant</li>
               </ul>
               <p className="mt-3 text-sm">We do not collect names, email addresses, or any personally identifiable information unless you choose to contact us.</p>
             </section>
@@ -144,7 +144,7 @@ export default function PrivacyPage() {
 
             <section>
               <h2 className="text-xl font-bold text-slate-800 mb-3">Funnel Analytics</h2>
-              <p>We measure whether a generator succeeds and whether visitors copy, regenerate, view a recommendation, follow an affiliate link, or interact with the newsletter form. Event payloads include the action, page, placement, and—when relevant—the generator type or affiliate partner. They never include a generated password, passphrase, or password-checker input.</p>
+              <p>We measure whether a generator succeeds and whether visitors copy, regenerate, view a recommendation, follow an affiliate link, or interact with the newsletter form. Event payloads are limited to the action, page, placement, and—when relevant—anonymous categories for page intent, generator type, or affiliate partner. The event contract rejects generated passwords, passphrases, password-checker inputs, entropy inputs, email addresses, and other unapproved fields.</p>
             </section>
 
             <section>

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,16 +1,76 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { buildFunnelEvent } from './analytics';
+import {
+  buildFunnelEvent,
+  FUNNEL_ACTIONS,
+  trackFunnelEvent,
+  type FunnelEventContext,
+} from './analytics';
 
-test('analytics payload exposes only defined, non-secret context', () => {
-  const unsafeInput = {
-    action: 'copy' as const,
-    page: '/',
-    placement: 'primary_generator',
-    generator: 'password' as const,
-    password: 'Never-collect-this-secret',
-  };
-  const payload = buildFunnelEvent(unsafeInput);
-  assert.deepEqual(payload, { action: 'copy', page: '/', placement: 'primary_generator', generator: 'password' });
-  assert.equal(JSON.stringify(payload).includes('Never-collect'), false);
+test('every supported action passes the shared event contract', () => {
+  for (const action of FUNNEL_ACTIONS) {
+    assert.deepEqual(buildFunnelEvent({ action, page: '/', placement: 'primary_generator' }), {
+      action,
+      page: '/',
+      placement: 'primary_generator',
+    });
+  }
+});
+
+test('analytics payload contains only validated categorical context', () => {
+  const payload = buildFunnelEvent({
+    action: 'affiliate_click',
+    page: '/blog/password-managers',
+    placement: 'comparison_table',
+    pageIntent: 'password_manager_comparison',
+    partner: 'nordpass',
+  });
+  assert.deepEqual(payload, {
+    action: 'affiliate_click',
+    page: '/blog/password-managers',
+    placement: 'comparison_table',
+    pageIntent: 'password_manager_comparison',
+    partner: 'nordpass',
+  });
+});
+
+test('forbidden and sensitive fields are rejected rather than silently emitted', () => {
+  for (const forbiddenKey of ['password', 'passphrase', 'checkerInput', 'entropyInput', 'email']) {
+    const unsafe = {
+      action: 'copy',
+      page: '/',
+      placement: 'primary_generator',
+      [forbiddenKey]: 'Never-collect-this-secret',
+    } as unknown as FunnelEventContext;
+    assert.throws(() => buildFunnelEvent(unsafe), /Unsupported analytics field/);
+  }
+});
+
+test('invalid actions and non-categorical metadata are rejected', () => {
+  assert.throws(
+    () => buildFunnelEvent({ action: 'outbound_click', page: '/', placement: 'content' } as unknown as FunnelEventContext),
+    /Unsupported analytics action/,
+  );
+  assert.throws(
+    () => buildFunnelEvent({ action: 'copy', page: '/', placement: 'Primary Generator' }),
+    /Invalid analytics placement/,
+  );
+});
+
+test('missing gtag fails safely and does not break the caller', () => {
+  assert.equal(trackFunnelEvent({ action: 'copy', page: '/', placement: 'primary_generator' }, {}), false);
+});
+
+test('valid events dispatch through gtag', () => {
+  const calls: unknown[][] = [];
+  const target = { gtag: (...args: unknown[]) => calls.push(args) };
+  assert.equal(
+    trackFunnelEvent({ action: 'generator_success', page: '/', placement: 'primary_generator', generator: 'password' }, target),
+    true,
+  );
+  assert.deepEqual(calls, [[
+    'event',
+    'generator_success',
+    { action: 'generator_success', page: '/', placement: 'primary_generator', generator: 'password' },
+  ]]);
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,32 +1,128 @@
-export type FunnelAction =
-  | 'generator_success'
-  | 'copy'
-  | 'regenerate'
-  | 'recommendation_view'
-  | 'affiliate_click'
-  | 'newsletter_view'
-  | 'newsletter_action';
+export const FUNNEL_ACTIONS = [
+  'generator_success',
+  'copy',
+  'regenerate',
+  'recommendation_view',
+  'affiliate_click',
+  'newsletter_view',
+  'newsletter_action',
+] as const;
+
+export const ALLOWED_EVENT_KEYS = [
+  'action',
+  'page',
+  'placement',
+  'pageIntent',
+  'generator',
+  'partner',
+] as const;
+
+export const GENERATOR_TYPES = ['password', 'passphrase'] as const;
+
+export type FunnelAction = (typeof FUNNEL_ACTIONS)[number];
+export type GeneratorType = (typeof GENERATOR_TYPES)[number];
 
 export interface FunnelEventContext {
   action: FunnelAction;
   page: string;
   placement: string;
-  generator?: 'password' | 'passphrase';
+  pageIntent?: string;
+  generator?: GeneratorType;
   partner?: string;
 }
 
-export function buildFunnelEvent(context: FunnelEventContext): FunnelEventContext {
-  return {
+export type FunnelEventPayload = Readonly<FunnelEventContext>;
+export type Gtag = (command: 'event', name: FunnelAction, payload: FunnelEventPayload) => void;
+
+type AnalyticsTarget = { gtag?: Gtag };
+
+const categoricalValue = /^[a-z0-9][a-z0-9_-]*$/;
+
+function assertCategorical(name: string, value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 80 || !categoricalValue.test(value)) {
+    throw new TypeError(`Invalid analytics ${name}`);
+  }
+}
+
+export function buildFunnelEvent(context: FunnelEventContext): FunnelEventPayload {
+  if (!context || typeof context !== 'object' || Array.isArray(context)) {
+    throw new TypeError('Analytics event must be an object');
+  }
+
+  const keys = Object.keys(context);
+  const unexpectedKey = keys.find((key) => !(ALLOWED_EVENT_KEYS as readonly string[]).includes(key));
+  if (unexpectedKey) {
+    throw new TypeError(`Unsupported analytics field: ${unexpectedKey}`);
+  }
+  if (!(FUNNEL_ACTIONS as readonly string[]).includes(context.action)) {
+    throw new TypeError('Unsupported analytics action');
+  }
+  if (typeof context.page !== 'string' || !context.page.startsWith('/') || context.page.length > 200) {
+    throw new TypeError('Invalid analytics page');
+  }
+  assertCategorical('placement', context.placement);
+
+  if (context.pageIntent !== undefined) assertCategorical('pageIntent', context.pageIntent);
+  if (context.partner !== undefined) assertCategorical('partner', context.partner);
+  if (context.generator !== undefined && !(GENERATOR_TYPES as readonly string[]).includes(context.generator)) {
+    throw new TypeError('Invalid analytics generator');
+  }
+
+  return Object.freeze({
     action: context.action,
     page: context.page,
     placement: context.placement,
+    ...(context.pageIntent ? { pageIntent: context.pageIntent } : {}),
     ...(context.generator ? { generator: context.generator } : {}),
     ...(context.partner ? { partner: context.partner } : {}),
-  };
+  });
 }
 
-export function trackFunnelEvent(context: FunnelEventContext): void {
-  if (typeof window === 'undefined') return;
-  const gtag = (window as Window & { gtag?: (command: string, name: string, payload: FunnelEventContext) => void }).gtag;
-  gtag?.('event', context.action, buildFunnelEvent(context));
+export function trackFunnelEvent(context: FunnelEventContext, target?: AnalyticsTarget): boolean {
+  try {
+    const analyticsTarget = target ?? (typeof window === 'undefined' ? undefined : (window as AnalyticsTarget));
+    if (!analyticsTarget?.gtag) return false;
+    const payload = buildFunnelEvent(context);
+    analyticsTarget.gtag('event', payload.action, payload);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createBrowserFunnelScript(): string {
+  const actions = JSON.stringify(FUNNEL_ACTIONS);
+  const allowedKeys = JSON.stringify(ALLOWED_EVENT_KEYS);
+  const generators = JSON.stringify(GENERATOR_TYPES);
+
+  return `
+    (function () {
+      var actions = ${actions};
+      var allowedKeys = ${allowedKeys};
+      var generators = ${generators};
+      var categoricalValue = /^[a-z0-9][a-z0-9_-]*$/;
+
+      window.spgTrackFunnelEvent = function (candidate) {
+        try {
+          if (!window.gtag || !candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return false;
+          if (Object.keys(candidate).some(function (key) { return allowedKeys.indexOf(key) === -1; })) return false;
+          if (actions.indexOf(candidate.action) === -1) return false;
+          if (typeof candidate.page !== 'string' || candidate.page.charAt(0) !== '/' || candidate.page.length > 200) return false;
+          if (typeof candidate.placement !== 'string' || !categoricalValue.test(candidate.placement) || candidate.placement.length > 80) return false;
+          if (candidate.pageIntent !== undefined && (typeof candidate.pageIntent !== 'string' || !categoricalValue.test(candidate.pageIntent) || candidate.pageIntent.length > 80)) return false;
+          if (candidate.partner !== undefined && (typeof candidate.partner !== 'string' || !categoricalValue.test(candidate.partner) || candidate.partner.length > 80)) return false;
+          if (candidate.generator !== undefined && generators.indexOf(candidate.generator) === -1) return false;
+
+          var payload = {};
+          allowedKeys.forEach(function (key) {
+            if (candidate[key] !== undefined) payload[key] = candidate[key];
+          });
+          window.gtag('event', payload.action, payload);
+          return true;
+        } catch (_) {
+          return false;
+        }
+      };
+    }());
+  `;
 }


### PR DESCRIPTION
Closes #443

## Summary
Adds one strict analytics event contract for the SPG funnel and routes browser interactions through it. Sensitive generator inputs and unknown fields are rejected, missing analytics fails safely, and the privacy notice now matches the implementation.

## Files changed
- Analytics component and shared event contract
- Focused contract/dispatch tests
- Privacy policy wording
- Analytics readiness diagnostic

## Verification
- npm test: 11/11 passed
- npm run lint: passed
- npm run build: passed
- git diff --check: passed
- Readiness diagnostic fails when the production key is absent and passes with a valid-format test key without printing it

## Handoff
Account dependency: configure NEXT_PUBLIC_GA_MEASUREMENT_ID in Vercel production. Keep this PR unmerged while the current AdSense review is active unless explicitly approved.

## Issue type
IMPROVEMENT