### PR TITLE
Restore reliable production funnel analytics

### DIFF
--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -1,90 +1,99 @@
+"use client";
+
 import Script from "next/script";
-import { createBrowserFunnelScript } from "@/lib/analytics";
+import { useEffect } from "react";
+import {
+  affiliatePartnerForUrl,
+  isAffiliateUrl,
+  trackFunnelEvent,
+  type FunnelEventContext,
+  type Gtag,
+} from "@/lib/analytics";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
+declare global {
+  interface Window {
+    dataLayer?: unknown[][];
+    gtag?: Gtag;
+    spgTrackFunnelEvent?: (context: FunnelEventContext) => boolean;
+  }
+}
+
 export default function Analytics() {
-  return (
-    <>
-      {GA_MEASUREMENT_ID ? (
-        <>
-          <Script
-            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-            strategy="afterInteractive"
-          />
-          <Script id="ga4-init" strategy="afterInteractive">
-            {`
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
-              gtag('config', '${GA_MEASUREMENT_ID}');
-            `}
-          </Script>
-        </>
-      ) : null}
-      <Script id="income-click-tracking" strategy="afterInteractive">
-        {`
-          ${createBrowserFunnelScript()}
+  useEffect(() => {
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = window.gtag || ((...args: unknown[]) => window.dataLayer?.push(args)) as Gtag;
+    window.spgTrackFunnelEvent = (context) => trackFunnelEvent(context, window);
 
-          function funnelEvent(action, placement, extra) {
-            return window.spgTrackFunnelEvent(Object.assign({
-              action: action,
-              page: window.location.pathname,
-              placement: placement
-            }, extra || {}));
-          }
+    if (GA_MEASUREMENT_ID) {
+      window.gtag("js", new Date());
+      window.gtag("config", GA_MEASUREMENT_ID);
+    }
 
-          document.addEventListener('click', function(event) {
-            var link = event.target && event.target.closest ? event.target.closest('a[href]') : null;
-            if (!link) return;
+    const funnelEvent = (
+      action: FunnelEventContext["action"],
+      placement: string,
+      extra: Partial<FunnelEventContext> = {},
+    ) => window.spgTrackFunnelEvent?.({
+      action,
+      page: window.location.pathname,
+      placement,
+      ...extra,
+    });
 
-            var url;
-            try {
-              url = new URL(link.href);
-            } catch (_) {
-              return;
-            }
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target;
+      const link = target instanceof Element ? target.closest<HTMLAnchorElement>("a[href]") : null;
+      if (!link || !isAffiliateUrl(link.href, link.rel)) return;
 
-            var isExternal = url.hostname && url.hostname !== window.location.hostname;
-            var href = link.href;
-            var isAffiliate = /sponsored|affiliate/i.test(link.rel || '') || /awin1|kqzyfj|cj/i.test(href);
-            var partner = 'external';
+      const placement = link.closest("main")
+        ? "content"
+        : link.closest("footer")
+          ? "footer"
+          : "site_navigation";
+      funnelEvent("affiliate_click", placement, { partner: affiliatePartnerForUrl(link.href) });
+    };
 
-            if (/kqzyfj/i.test(href)) partner = 'nordpass';
-            else if (/awin1.*15132/i.test(href)) partner = 'nordvpn';
-            else if (/awin1.*123620/i.test(href)) partner = 'nordprotect';
-            else if (/awin1/i.test(href)) partner = 'awin';
+    document.addEventListener("click", handleClick);
 
-            if (isAffiliate || isExternal) {
-              var placement = link.closest('main') ? 'content' : link.closest('footer') ? 'footer' : 'site_navigation';
-              if (isAffiliate) {
-                funnelEvent('affiliate_click', placement, { partner: partner });
-              }
-            }
-          });
+    const seenRecommendations = new WeakSet<Element>();
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting || seenRecommendations.has(entry.target)) return;
+        seenRecommendations.add(entry.target);
+        const isNewsletter = entry.target.tagName === "IFRAME";
+        funnelEvent(
+          isNewsletter ? "newsletter_view" : "recommendation_view",
+          isNewsletter ? "homepage_newsletter" : "affiliate_cta",
+        );
+      });
+    }, { threshold: 0.5 });
 
-          var seenRecommendations = new WeakSet();
-          var observer = new IntersectionObserver(function(entries) {
-            entries.forEach(function(entry) {
-              if (!entry.isIntersecting || seenRecommendations.has(entry.target)) return;
-              seenRecommendations.add(entry.target);
-              var isNewsletter = entry.target.tagName === 'IFRAME';
-              funnelEvent(isNewsletter ? 'newsletter_view' : 'recommendation_view', isNewsletter ? 'homepage_newsletter' : 'affiliate_cta');
-            });
-          }, { threshold: 0.5 });
+    document
+      .querySelectorAll('a[rel~="sponsored"], iframe[title="Security newsletter signup"]')
+      .forEach((element) => observer.observe(element));
 
-          document.querySelectorAll('a[rel~="sponsored"], iframe[title="Security newsletter signup"]').forEach(function(element) {
-            observer.observe(element);
-          });
+    const handleBlur = () => {
+      const active = document.activeElement;
+      if (active instanceof HTMLIFrameElement && active.title === "Security newsletter signup") {
+        funnelEvent("newsletter_action", "homepage_newsletter");
+      }
+    };
+    window.addEventListener("blur", handleBlur);
 
-          window.addEventListener('blur', function() {
-            var active = document.activeElement;
-            if (active && active.tagName === 'IFRAME' && active.title === 'Security newsletter signup') {
-              funnelEvent('newsletter_action', 'homepage_newsletter');
-            }
-          });
-        `}
-      </Script>
-    </>
-  );
+    return () => {
+      document.removeEventListener("click", handleClick);
+      window.removeEventListener("blur", handleBlur);
+      observer.disconnect();
+      delete window.spgTrackFunnelEvent;
+    };
+  }, []);
+
+  return GA_MEASUREMENT_ID ? (
+    <Script
+      src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+      strategy="afterInteractive"
+    />
+  ) : null;
 }

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,11 +1,22 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  affiliatePartnerForUrl,
   buildFunnelEvent,
   FUNNEL_ACTIONS,
+  isAffiliateUrl,
   trackFunnelEvent,
   type FunnelEventContext,
 } from './analytics';
+
+test('affiliate destinations are recognized and categorized without storing the URL', () => {
+  assert.equal(isAffiliateUrl('https://www.awin1.com/cread.php?awinmid=15132'), true);
+  assert.equal(isAffiliateUrl('https://example.com/product', 'nofollow sponsored'), true);
+  assert.equal(isAffiliateUrl('https://example.com/reference'), false);
+  assert.equal(affiliatePartnerForUrl('https://www.awin1.com/cread.php?awinmid=15132'), 'nordvpn');
+  assert.equal(affiliatePartnerForUrl('https://www.awin1.com/cread.php?awinmid=123620'), 'nordprotect');
+  assert.equal(affiliatePartnerForUrl('https://www.kqzyfj.com/click-123'), 'nordpass');
+});
 
 test('every supported action passes the shared event contract', () => {
   for (const action of FUNNEL_ACTIONS) {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -32,11 +32,27 @@ export interface FunnelEventContext {
 }
 
 export type FunnelEventPayload = Readonly<FunnelEventContext>;
-export type Gtag = (command: 'event', name: FunnelAction, payload: FunnelEventPayload) => void;
+export interface Gtag {
+  (command: 'event', name: FunnelAction, payload: FunnelEventPayload): void;
+  (command: 'js', initializedAt: Date): void;
+  (command: 'config', measurementId: string): void;
+}
 
 type AnalyticsTarget = { gtag?: Gtag };
 
 const categoricalValue = /^[a-z0-9][a-z0-9_-]*$/;
+
+export function isAffiliateUrl(href: string, rel = ''): boolean {
+  return /sponsored|affiliate/i.test(rel) || /awin1|kqzyfj|cj/i.test(href);
+}
+
+export function affiliatePartnerForUrl(href: string): string {
+  if (/kqzyfj/i.test(href)) return 'nordpass';
+  if (/awin1.*15132/i.test(href)) return 'nordvpn';
+  if (/awin1.*123620/i.test(href)) return 'nordprotect';
+  if (/awin1/i.test(href)) return 'awin';
+  return 'external';
+}
 
 function assertCategorical(name: string, value: unknown): asserts value is string {
   if (typeof value !== 'string' || value.length === 0 || value.length > 80 || !categoricalValue.test(value)) {


### PR DESCRIPTION
Closes #447

## What changed

- initialize GA4 and the funnel tracker from a hydrated client component instead of dynamically injected inline scripts
- preserve delegated affiliate-click, recommendation-view, and newsletter tracking with cleanup on unmount
- centralize and test affiliate-link recognition and partner categorization
- retain the strict privacy-safe event allowlist; URLs, generated passwords, email addresses, and other user-entered values are never emitted

## Verification

- `npm test` — 12 tests passed
- `npm run lint` — passed
- `npm run build` — passed (46 static/SSG routes generated)
- `git diff --check` — passed
- Issue body snapshot at claim: `df30dae78c9c2337`
- Original queue: `agios:escalate-codex`

## Risk and rollout

Medium risk because this changes production analytics initialization. Auto-merge is disabled; verify GA4 Realtime/DebugView after deployment before relying on funnel reports.
