### PR TITLE
fix: remove dead VPN recommendation routes

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -57,11 +57,6 @@ const nordProtectRecommendedSlugs = new Set([
 ]);
 
 const nordVpnRecommendedSlugs = new Set([
-  'nordvpn-review-2026',
-  'nordvpn-vs-expressvpn',
-  'how-to-use-a-vpn-for-privacy',
-  'vpn-worth-it-2026',
-  'vpn-for-remote-work',
   'public-wifi-security-tips',
   'password-security-for-remote-workers',
 ]);

--- a/src/app/components/MoneyNextStep.tsx
+++ b/src/app/components/MoneyNextStep.tsx
@@ -29,8 +29,8 @@ export default function MoneyNextStep({ tags, category }: { tags: string[]; cate
           }
         : vpnMatchers.some((term) => topicText.includes(term))
           ? {
-              href: "/blog/nordvpn-review-2026",
-              label: "Review VPN protection",
+              href: "/blog/public-wifi-security-tips",
+              label: "Read the public Wi-Fi security guide",
               body: "A password manager protects accounts. A VPN protects traffic when you are on public or untrusted networks.",
             }
           : passwordManagerMatchers.some((term) => topicText.includes(term))

--- a/src/app/recommended-tools/page.tsx
+++ b/src/app/recommended-tools/page.tsx
@@ -357,7 +357,7 @@ export default function RecommendedToolsPage() {
           <h2 className="mb-3 text-lg font-bold text-slate-800">Related buying guides</h2>
           <ul className="grid gap-2 text-sm text-slate-600 md:grid-cols-2">
             <li><Link className="text-indigo-600 hover:underline" href="/blog/nordpass-review-2026">NordPass review</Link></li>
-            <li><Link className="text-indigo-600 hover:underline" href="/blog/nordvpn-review-2026">NordVPN review</Link></li>
+            <li><Link className="text-indigo-600 hover:underline" href="/blog/public-wifi-security-tips">Public Wi-Fi security guide</Link></li>
             <li><Link className="text-indigo-600 hover:underline" href="/blog/free-vs-paid-password-managers-2026">Free vs paid password managers</Link></li>
             <li><Link className="text-indigo-600 hover:underline" href="/blog/password-manager-vs-browser-autofill">Password manager vs browser autofill</Link></li>
           </ul>

--- a/src/lib/articleCommerce.ts
+++ b/src/lib/articleCommerce.ts
@@ -359,48 +359,6 @@ export const articleCommerceGuides: Record<string, ArticleCommerceGuide> = {
       },
     ],
   },
-  "nordvpn-review-2026": {
-    eyebrow: "Best fit at a glance",
-    title: "Who NordVPN is best for",
-    summary: "NordVPN is strongest when you need reliable privacy on public networks, travel-friendly coverage, and a clean path into a broader security stack.",
-    cards: [
-      {
-        title: "Choose NordVPN if you use public Wi-Fi often",
-        body: "Best for travelers, remote workers, and anyone who wants a simple, audited VPN with broad device support.",
-        href: affiliates.nordvpn.url,
-        cta: "Try NordVPN",
-        external: true,
-        monetized: affiliates.nordvpn.monetized,
-      },
-      {
-        title: "Add NordPass if password reuse is still the bigger risk",
-        body: "A VPN protects traffic, but it does not fix weak or reused credentials across your accounts.",
-        href: "/blog/password-manager-vs-browser-autofill",
-        cta: "Compare password managers",
-      },
-      {
-        title: "Add NordProtect if a breach is already part of the picture",
-        body: "Identity monitoring helps when your concern has shifted from privacy to active exposure and fraud cleanup.",
-        href: "/blog/best-identity-theft-protection-2026",
-        cta: "Review identity protection",
-      },
-    ],
-    followUpTitle: "Build the rest of the stack in order",
-    followUps: [
-      {
-        title: "Secure the accounts behind your VPN",
-        body: "Strong passwords and 2FA still matter more than the network layer once you sign in.",
-        href: "/blog/password-security",
-        cta: "Open the security hub",
-      },
-      {
-        title: "See the broader tools page",
-        body: "Useful if you want one place to compare managers, monitoring, and device-security options.",
-        href: "/recommended-tools",
-        cta: "See all recommendations",
-      },
-    ],
-  },
   "data-breach-what-to-do": {
     eyebrow: "Breach response stack",
     title: "Fix the exposed login first, then monitor the identity risk",


### PR DESCRIPTION
Closes #449

## Summary
- Replace the retired NordVPN review link with the live public-Wi-Fi security guide.
- Remove retired VPN slugs from recommendation routing and delete the orphaned commerce map entry.
- Keep valid external affiliate destinations unchanged.
- Verify the existing AdSense ads.txt record without changing it.

## Verification
- `npm test` — pass (12 tests).
- `npm run lint` — pass.
- `npx next build --webpack` — pass (production build, 46 routes).
- `npm run verify:urls` — pass.
- `git diff --check` — pass.
- `npm run check:adsense` — local ads.txt and required trust files pass; remote fetch is unavailable in the sandbox.
- `public/ads.txt` remains `google.com, pub-6175161566333696, DIRECT, f08c47fec0942fa0`.

## Risk and handoff
Low risk. The removed NordVPN article was already intentionally retired by the URL-consolidation decision; this only removes links/data that still pointed at it. After merge, smoke-test the recommended-tools page and AdSense sites UI.

Auto-merge allowed: yes