### PR TITLE
Restore transparent checklist affiliate callout

### DIFF
--- a/src/app/password-safety-checklist/page.tsx
+++ b/src/app/password-safety-checklist/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import Script from 'next/script';
+import AffiliateDisclosure from '../components/AffiliateDisclosure';
+import NordPassInContentCallout from '../components/NordPassInContentCallout';
 
 export const metadata: Metadata = {
   title: 'Password Safety Checklist | Strong Password Generator',
@@ -95,6 +97,11 @@ export default function PasswordSafetyChecklistPage() {
                 </div>
               </section>
             ))}
+          </div>
+
+          <div className="mt-8">
+            <AffiliateDisclosure />
+            <NordPassInContentCallout />
           </div>
 
           <section className="mt-8 rounded-2xl border border-indigo-200 bg-indigo-50 p-5">


### PR DESCRIPTION
Closes #459

## What changed
- Restored the existing NordPass in-content callout after the password-safety checklist.
- Added the existing affiliate disclosure immediately before the callout.

## Why
The current production checklist had a clear password-manager recommendation but no adjacent commercial next step. The callout was present in prior repository history but absent from current `main`; the affiliate destination was verified to resolve to NordPass. The disclosure keeps the monetization surface transparent.

## Verification
- `npm run check:adsense`
- `npm test` (12 passing tests)
- `npm run lint`
- `npm run verify:urls`
- `npx next build --webpack`
- `git diff --check`
- Issue body snapshot at claim: `badfd43a5dc4454f`

## Handoff
- Scope: `src/app/password-safety-checklist/page.tsx` only.
- Risk: LOW; no metadata, schema, AdSense script, affiliate URL, or checklist copy changed.
- Rollback: revert commit `fb442c8`.
- Auto-merge allowed by issue contract: yes.