### PR TITLE
Mark NordPass callout link sponsored

### DIFF
--- a/src/app/components/NordPassInContentCallout.tsx
+++ b/src/app/components/NordPassInContentCallout.tsx
@@ -18,7 +18,7 @@ const NordPassInContentCallout: React.FC = () => {
         <a
           href={nordpass.url}
           target="_blank"
-          rel="noopener noreferrer"
+          rel={nordpass.monetized ? "noopener noreferrer sponsored" : "noopener noreferrer"}
           className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition duration-300 ease-in-out"
         >
           {nordpass.cta}


### PR DESCRIPTION
Closes #461

## What changed
- Marked the existing monetized NordPass in-content link with the standard `sponsored` relationship value.
- Preserved the destination, CTA text, styling, and component layout.

## Why
The callout now powers a live high-intent page, but its anchor was the only SPG affiliate component not emitting the site's established `sponsored` relationship value. This makes the live commercial relationship explicit without changing the destination or user experience.

## Verification
- `npm run check:adsense`
- `npm test` (12 passing tests)
- `npm run lint`
- `npx next build --webpack`
- `git diff --check`
- Issue body snapshot at claim: `898d8a3263ba74d0`

## Handoff
- Scope: `src/app/components/NordPassInContentCallout.tsx` only.
- Risk: LOW; no URL, analytics, metadata, AdSense, or content changes.
- Rollback: revert commit `53056a8`.
- Auto-merge allowed by issue contract: yes.